### PR TITLE
fix(home-assistant): podsecurity context

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -65,11 +65,6 @@ spec:
         enabled: false
       startup:
         enabled: false
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: OnRootMismatch
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
use root for both codeserver and hass