### PR TITLE
feat(nginx): Add local analytics snippet to public Helm releases via Nginx annotations

### DIFF
--- a/kubernetes/apps/default/immich/app/server/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/server/helmrelease.yaml
@@ -154,6 +154,10 @@ spec:
           hajimari.io/enable: "false"
           nginx.ingress.kubernetes.io/proxy-body-size: "0"
           nginx.ingress.kubernetes.io/upstream-hash-by: "$client_ip"
+          nginx.ingress.kubernetes.io/configuration-snippet: |
+            sub_filter </head>
+                '</head><script defer src="https://analytics.thiagoalmeida.xyz/script.js" data-website-id="086445c0-1f67-46c4-9246-bd1f74278421"></script>';
+            sub_filter_once on;
         hosts:
           - host: &public-domain photos.${PUBLIC_DOMAIN}
             paths:

--- a/kubernetes/apps/default/photoprism/app/helmrelease.yaml
+++ b/kubernetes/apps/default/photoprism/app/helmrelease.yaml
@@ -174,6 +174,10 @@ spec:
           external-dns.alpha.kubernetes.io/target: "ingress.${PUBLIC_DOMAIN}"
           hajimari.io/enable: "false"
           nginx.ingress.kubernetes.io/proxy-body-size: 4G
+          nginx.ingress.kubernetes.io/configuration-snippet: |
+            sub_filter </head>
+                '</head><script defer src="https://analytics.thiagoalmeida.xyz/script.js" data-website-id="ac25a4a6-ddab-45cb-ab05-1049354c40ea"></script>';
+            sub_filter_once on;
         hosts:
           - host: &public-domain portfolio.${PUBLIC_DOMAIN}
             paths:


### PR DESCRIPTION
This commit introduces a new feature that adds a local analytics snippet to public Helm releases through Nginx annotations. The change allows for more detailed monitoring and analysis of application performance.