### PR TITLE
feat(home-assistant): Update Home Assistant container image

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -40,8 +40,8 @@ spec:
         containers:
           main:
             image:
-              repository: ghcr.io/home-assistant/home-assistant
-              tag: 2024.11.3@sha256:988ae0f8bab0620d7e9abdcf07f8a8f6d88f5ae301749e61e6cf00aaed13a19b
+              repository: ghcr.io/onedr0p/home-assistant
+              tag: 2024.11.3@sha256:f45f502b1738e46eb435fbc8947cdcc2574f3713b156c6738129ea2ea9b49018
             envFrom:
               - secretRef:
                   name: home-assistant-secret


### PR DESCRIPTION
- Changed image repository from `ghcr.io/home-assistant/home-assistant` to `ghcr.io/onedr0p/home-assistant`
- Updated image tag to `2024.11.3@sha256:f45f502b1738e46eb435fbc8947cdcc2574f3713b156c6738129ea2ea9b49018`

Reason:
https://github.com/home-assistant/core/issues/132336#issuecomment-2520407648