### PR TITLE
feat: Add node-exporter targets for OpenWRT device

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -467,6 +467,11 @@ spec:
               - targets:
                   - 192.168.100.102:9100
                   - 192.168.100.103:9100
+                  - 192.168.100.1:9100
+          - job_name: node-exporter-openwrt
+            static_configs:
+              - targets:
+                  - 192.168.100.1:9101
         retention: 15d
         resources:
           requests:


### PR DESCRIPTION
- Added job_name: node_exporter_openwrt with target 192.168.100.1:9101
- Added additional node_exporter target at 192.168.100.1:9100