### PR TITLE
fix(headlamp): update Helm repository URL

### DIFF
--- a/kubernetes/flux/repositories/helm/headlamp.yaml
+++ b/kubernetes/flux/repositories/helm/headlamp.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 2h
-  url: https://headlamp-k8s.github.io/headlamp/
+  url: https://kubernetes-sigs.github.io/headlamp/


### PR DESCRIPTION
Update headlamp helm repository URL in headlamp.yaml to point to the correct Kubernetes-SIGs location.