### PR TITLE
feat(media): add jellyseerr application

### DIFF
--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app jellyseerr
+  namespace: media
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      jellyseerr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/fallenbagel/jellyseerr
+              tag: 2.5.2@sha256:2a611369ad1d0d501c2d051fc89b6246ff081fb4a30879fdc75642cf6a37b1a6
+            env:
+              TZ: ${TIMEZONE}
+              LOG_LEVEL: "info"
+              PORT: &port 80
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: jellyseerr
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        enabled: true
+        className: nginx
+        annotations:
+          nginx.ingress.kubernetes.io/whitelist-source-range: ${LOCAL_SUBNETS}
+          hajimari.io/enable: "true"
+        hosts:
+          - host: &host requests.${SECRET_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+      public:
+        enabled: true
+        className: nginx
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "ingress.${PUBLIC_DOMAIN}"
+          hajimari.io/enable: "false"
+        hosts:
+          - host: requests.${PUBLIC_DOMAIN}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+        tls: []
+    persistence:
+      config:
+        enabled: true
+        retain: true
+        storageClass: longhorn
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 4Gi
+        globalMounts:
+          - path: /app/config
+      config-cache:
+        enabled: true
+        storageClass: longhorn
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 4Gi
+        globalMounts:
+          - path: /app/config/cache
+      config-logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/config/logs
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/media/jellyseerr/app/jellyseerr.sops.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/jellyseerr.sops.yaml
@@ -1,0 +1,33 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: jellyseerr-secret
+    namespace: media
+type: Opaque
+stringData:
+    DB_TYPE: ENC[AES256_GCM,data:NYSQDrRrLj0=,iv:ZH3a8kkXAC40Zf+PasmryYlJdqwgOBDZaq7c4b7bsCg=,tag:d0b4Dhzxl9A4+LcbzpUYvg==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:sG46906lRM9rQWbpjWMyMhmXELd0A/sbqRvzrEvz7xDt5pQ/4L0=,iv:Nml1ysNxGoNnKfiBy6fOSuI3+mVWNIUxxgOD2dshVvk=,tag:V7kYLhgUSEKZ8BISt08T3g==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:raB/zA==,iv:M7yoTPqepKzEnRvJQoTvqCXLrDF3KGxb4c/SuaWk7CI=,tag:rr2sLGUwQ3jl5MJGXF+qww==,type:str]
+    DB_USER: ENC[AES256_GCM,data:eYfAw99DZkdmtw==,iv:H51HyQVaquEKRzbKqZHVKDl3k7XEZqLT14zJ2oGivXE=,tag:uCYlsB6owMqFvlZuVHUdng==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:GH/Ss1+Oqb/hMQfhqU/4XI2Luno8zwWPsEiGG+xZYd0=,iv:sBRu2Qcb01HYh8hB2iSk3ERDGp3OvAvD0VnTBasqm/k=,tag:zTLcKUAcdrC3J2L5r1Z/hQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoRGdmVUFsejVWc214TGM2
+            dHpQTitJbFlNWWNzN08zOU9vT3BUd1EzblRVClhodnMzdzZ6STYwaG1jT0Fma3VU
+            TWVtS0t0QzltTjRWR0haSlFFajJaRFUKLS0tIEhoZUpFcXg5Sk1oSXArRG44Ulpa
+            MC92UWQ3cE1OTmxYaUVzSnEzZ1FZcEUKSRrOrbXTkgBWuct/41n+QGqXN63vTbPl
+            djPVZZ1G5qBV+HXdz/VfPuP7J4zG3ZXNnDMXnu++9lc77cqdXUHsdw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-04-17T15:32:30Z"
+    mac: ENC[AES256_GCM,data:CDJlvHW8SGOU7N5yFwaeCUdVMpVvQiNZiZaHoFPIXL4r9am5NfI6Hg11VgbB8362ha69mIkPHNTXVkzk278b6+JekyjvSZYcGO0UmV+qC/4lk3kOaJVjIOKxmU8Ro++a91pC1Jpbg7kqKqiTj5J6j0c30MLKJB7dO+3oJ2h+N0k=,iv:QnKUdD+//+Lp0YySrx2WnsQdJdlDsjL+b45eIqMDD0E=,tag:zHvQgD0IUJMPXcHQ3ssAEg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.0

--- a/kubernetes/apps/media/jellyseerr/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./jellyseerr.sops.yaml

--- a/kubernetes/apps/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/media/jellyseerr/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: overseerr
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/media/jellyseerr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./namespace.yaml
   - ./bazarr/ks.yaml
   - ./jellyfin/ks.yaml
+  - ./jellyseerr/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./radarr/ks.yaml


### PR DESCRIPTION
This commit introduces the jellyseerr application to the media stack.

- Added a new directory for jellyseerr configuration.
- Defined a Kustomization for jellyseerr, including:
    - HelmRelease for deployment.
    - Secret for database credentials.
    - Kustomization to manage resources.
- Integrated jellyseerr into the overall media Kustomization.

This allows users to manage their media requests through jellyseerr, integrating seamlessly with the existing media server setup.