### PR TITLE
feat(postgres): upgrade postgres 17 and update services using it

### DIFF
--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./namespace.yaml
   - ./mariadb/ks.yaml
   - ./postgres/ks.yaml
+  - ./postgres17/ks.yaml
   - ./redis/ks.yaml

--- a/kubernetes/apps/databases/postgres17/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/postgres17/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bitnami/charts/275b8af69ff830bd5cb6e02ad4d3839dfaa6c234/bitnami/postgresql/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: postgresql17
+  namespace: databases
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: postgresql
+      version: 16.6.3
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      postgresql:
+        auth:
+          existingSecret: postgresql-secret
+          database: main
+      security:
+        allowInsecureImages: true
+    image:
+      registry: ghcr.io
+      repository: thiagoalmeidasa/bitnami-postgres-pgvecto-rs
+      tag: 17.4.0-debian-12-r16@sha256:38120f802af199ec76e2cedb8fccdce622e822c72b876e43d9ddebc0d1811ce1
+    primary:
+      persistence:
+        enabled: true
+        existingClaim: postgres17
+      pdb:
+        create: true
+        minAvailable: 1
+      resourcesPreset: "small"
+      ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    backup:
+      enabled: true
+      cronjob:
+        storage:
+          storageClass: longhorn
+          size: 40Gi
+        command:
+          - /bin/sh
+          - -c
+          - |
+            BACKUP_DIR="$PGDUMP_DIR"
+            BACKUPS_TO_KEEP=7
+
+            echo "Current backups in $BACKUP_DIR:"
+            ls -lh $BACKUP_DIR/pg_dumpall-*.pgdump
+
+            pg_dumpall --clean --if-exists --load-via-partition-root --quote-all-identifiers --no-password --file=$BACKUP_DIR/pg_dumpall-$(date '+%Y-%m-%d-%H-%M').pgdump
+
+            if [ $? -eq 0 ]; then
+              echo "Backup created successfully."
+
+              BACKUPS_TO_DELETE=$(ls -1t $BACKUP_DIR/pg_dumpall-*.pgdump | tail -n +$((BACKUPS_TO_KEEP+1)))
+
+              if [ -n "$BACKUPS_TO_DELETE" ]; then
+                echo "Deleting old backups:"
+                echo "$BACKUPS_TO_DELETE"
+
+                echo "$BACKUPS_TO_DELETE" | xargs -I {} rm -- {}
+              else
+                echo "No backups to delete."
+              fi
+            else
+              echo "Backup creation failed. Old backups will not be deleted."
+              exit 1
+            fi

--- a/kubernetes/apps/databases/postgres17/app/kustomization.yaml
+++ b/kubernetes/apps/databases/postgres17/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  # - ./secret.sops.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/databases/postgres17/app/pvc.yaml
+++ b/kubernetes/apps/databases/postgres17/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres17
+  namespace: databases
+  labels:
+    recurring-job-group.longhorn.io/backup: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/databases/postgres17/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/postgres17/app/secret.sops.yaml
@@ -1,0 +1,30 @@
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+    name: postgresql-secret
+    namespace: databases
+stringData:
+    password: ENC[AES256_GCM,data:o44n7C9D3Hfanjb2uRwskg==,iv:xAKkM2DrE/65UtirL/CLfaWcUBJCojRpiS1QgXu/8hs=,tag:gJyMEbcKjoZcTcjnYMclew==,type:str]
+    postgres-password: ENC[AES256_GCM,data:ofitML4csKis3anzOHiokA==,iv:iloVL6c3nILP1RnnFQcX7U7/Fr5fC/dGQjHK8qnA1NQ=,tag:ubPQpfe5rPcbJwACtPiIMw==,type:str]
+    replication-password: ENC[AES256_GCM,data:RbHEIpyAj/LfXMhp2SYv3g==,iv:S03PAIHlxvvNaQdocOR7kqJEUrx13zx0pcFasY5h0yE=,tag:+JsrqLmn7dktmRMCeMIY6g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhM1RwWDdnWXBLbmZTMXRL
+            QTB2aXFJeTl3cVJaODlrc1hRSjM2TU5RK25zCmhLMy9SN2lCdVVJejZ1S1BrOUhp
+            VkM1YXNMRWVPS0tocXJuaThVYitrdFUKLS0tIEFiajB3RVlKay9tNXpyRjZTa1Nk
+            QmgzdkJnZVIwaUphL0Y3MUVRMENmVmsKPQk8e8pxuQZCA0dBj0rmEkyHrf1Bh8T8
+            6kYUOksoI8/zALXmO+r1tT45yh5Hox5bAh9ufF57wlVEXMB6R8OpZA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2023-05-28T16:32:41Z"
+    mac: ENC[AES256_GCM,data:r1RNDOH4cLwNWOFJFEWMPIwuxue0qj+NJYNFl6b26rAeaOHtESFMdYLVGiETe0fRxLJyg2yEDHZKL/MJBdShib0JI0r/C68OqtR/cKxXpHYlN4FfiYhptF2BoTFG2eYhzq9w5jgRxnydy8thqBNo0/s65l6WVbeD/MyS2qUJTEI=,iv:WFOP1VpcUJsm2oPhjfU8YwCwahPw+Ra82YT7toOMMDU=,tag:R6cOkesPXJGZWlQ4+H/21A==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/kubernetes/apps/databases/postgres17/ks.yaml
+++ b/kubernetes/apps/databases/postgres17/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postgresql17
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/databases/postgres17/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/immich/app/secret.sops.yaml
+++ b/kubernetes/apps/default/immich/app/secret.sops.yaml
@@ -4,11 +4,11 @@ metadata:
     name: immich-secret
 type: Opaque
 stringData:
-    DB_HOSTNAME: ENC[AES256_GCM,data:zospraxw5tfskwzVyz4xyRmL+l2egTTwEm1VARuVJYBsnLT/suE=,iv:YUYp0h7Nn7caVEC2wjfIh6umhUhbBJzOu5P4q8wLExk=,tag:W0cM2lI2HMYLyDHDO0boaw==,type:str]
-    DB_PORT: ENC[AES256_GCM,data:5YAuTw==,iv:UB22q926nEApd60fVhn0emQKmLYlxZRHH/Oayepb9AM=,tag:61yaWexZI2YRBhO0aUcSgg==,type:str]
-    DB_DATABASE_NAME: ENC[AES256_GCM,data:Dqu0OSb9,iv:9xnq+gE9Y///5AxSFWa5zPxjmn3MWH0pQxWcVAUL40M=,tag:eKigPBVLeYJ2n5HqmR+LOg==,type:str]
-    DB_PASSWORD: ENC[AES256_GCM,data:OT3b3LwfqaaHGgnJQ7rm3hVzYkq3GuaQX3l0Wvj7m40=,iv:l3cA8XmkMqfoGZQGIIUqvLInYz1lSt0NKcce7nXUvgM=,tag:CUZLTEm3yQLn8N3jnhgP5w==,type:str]
-    DB_USERNAME: ENC[AES256_GCM,data:dG03vNCX,iv:biXtT7jwkWU7MQhVgZ0U2et1kJmV13d2ul7a2QIVX0A=,tag:MwQ8L69F6ZQzYdq9SXCTNQ==,type:str]
+    DB_HOSTNAME: ENC[AES256_GCM,data:94L7fZ8wyXlfUZFEAieBnYexksHfYfJxLJ6Bka2/BOo41p5imXuVdQ==,iv:yZ+EjVqzMVFRguXNqdxUPJ4v0TmN3UoWYTUpz3JBqMk=,tag:VzEDxbmFxpRUvN5pVX9yQg==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:lbbTaw==,iv:J9dpNBOGLpGl/UsPKqrqEOOBP6PTGaaQh7CkKnSlkAA=,tag:aA4hd4zliRPYu6ImMXHkXQ==,type:str]
+    DB_DATABASE_NAME: ENC[AES256_GCM,data:jpFOtxMU,iv:Ch3TRRQa6yFuYgLnb/LDIFU0TPMwujIWY9ztAaD8vlE=,tag:WqnY5ucC1yEGVPEU39SCYw==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:3y0SDpyqJC8OTmAFyWhEySMDF/2R2nEWvJBrk+qSe2M=,iv:fQv0MWdxvKLyAmdsqtlbuQy5zRz1ORj2TNDBofLFNpY=,tag:F/9VIbKF+YYEV7TBVVfj/g==,type:str]
+    DB_USERNAME: ENC[AES256_GCM,data:9bnyoVD6,iv:bK113QIwZ1t9T0Y1eWEYNiwEMOs9ULTLzZoCywbhmY0=,tag:AOGH90Lh8l4DFu7NZnFQ8w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -18,14 +18,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYSWhocS81U1d4R0pnck5q
-            S2JKdVpCYjNKcGRQTWZWcWprYUZCV1hJY0UwClZsdkQvMGs4SGo0VzhWRCtXZjhq
-            YllFWHMrMEJvU1pwNEtic3ptS1FrZkEKLS0tIGQ2VWQwY2xKR05relU5b2I1TVdT
-            MldTTGZOOVpVNXJTWVVtSGwwT2pEcmsKmUHkCFD70/4I8Yf7b16+EOtq9kO2/BoD
-            RZ10V76wGrG6PxQ3apyjpZxr1ICfFBgr5uYFF0RqynOtTAIqzV01iw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0UEZFUjZzMkNvUk9MekpG
+            M3FDbmZFWmRXWkJqNnRpRWJEbzUxUkNwWkFJCm56OU9DZ2pVQmpENkNibW9WQWxN
+            eVhXU1JhaGtvbk1nUUkvWVZjUVlwQ0kKLS0tIDdRblNWb0dOT09zY1pYZkNPL0Ez
+            UU1NUDRWSlhIWGR5V0hHOTJxcGpYYWcKXVF6LslDm/0ncklVtHntq+RQDJrzI5Wc
+            0KrwuVMn7Enfqs8ldJEaZI1NYCEgdUkr16GHEOxcBtRg0xjvi1FLCg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-17T23:33:00Z"
-    mac: ENC[AES256_GCM,data:1K1R4++eo77icmgYB4xSZ8YESS9Xi1JkALoRSJH2aRvwP7tM+SQH6zY87P8hRifJbt2VKkFk1qEeobQkt0PewQpc/bOb6kbg8IDx6NOim6Lbuf00Hfsr1Hcddvcw3WSb47ktWzJru5b51ADxAJwR17wcC5oij3Xkuq16oXfLZds=,iv:FQcKEky+1LRoofL/NcKZ/sC7AHjYOSoryNfSTI2xP2A=,tag:nQ94/PaFCSXEFoh9lX2NtQ==,type:str]
+    lastmodified: "2025-04-22T12:38:17Z"
+    mac: ENC[AES256_GCM,data:xrQFqrWIUbGmsHS/E4ZeNluJCJ3O6cimugUtmxw6w+hxio29wdXqYuhNn/jwYL99NPqop/+zEJtGU+sjeyNisw7XcOi/dOeNvSxp7SpFph3RzwUIT8ovvdcXoBCtoJFAZXOiBaWg/3r4YC0alD2fad9YVD9i7hXHXhar2hXxUhk=,iv:otOPV9wuOB73gSJEkubAPpQhM4GyBgDFCgz5EecPUGo=,tag:+J24wmvHIhPA+tXg9xlkcg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.9.0

--- a/kubernetes/apps/default/umami/app/secret.sops.yaml
+++ b/kubernetes/apps/default/umami/app/secret.sops.yaml
@@ -5,8 +5,8 @@ metadata:
     name: umami-secret
     namespace: default
 stringData:
-    POSTGRES_URL: ENC[AES256_GCM,data:0OYjD6Z6XUD0y/n8+4wXLomEFJdee16DIIVQRTMowmEKFs/Z+a4ZzwY3iV02x6mRv/m9tSSyxSzvxUbeDXg8lVJtYtjZHJqt2l2n67ihEACUmXZAKfgZ+q2A4QM1RAJHHe2V/0s=,iv:20p0DVBRi5Ztt9dbIjRQq10+TDZQ42Q15apYJScet4E=,tag:XQVKN7U13vdmZy7HrLrdZg==,type:str]
-    REDIS_URL: ENC[AES256_GCM,data:crjj06yK4juQD9H0nrp17JxviMr0Vhm+p4jIwC7DSavgWsKDTaXHfy9tC8uTg5VuKcv9gtk=,iv:i5oqRRQg+AWxu3RFtfaYhTTHUH6DH9jrRnHxQrr7rnY=,tag:0AwDg6nvdLbWhqM5WLBM4g==,type:str]
+    POSTGRES_URL: ENC[AES256_GCM,data:B+6UFuQYpX7uJ5bmUI8KShkpzLeshBj+hXhmugpu6e6FG52ML3cg5DNUHmLGCubUcVcyKYmIoQRALx7SLCSR+bHoACCME67UrnnYtdeiTPASEVBeSjLA8tn1oLbbWiCkgHufXTMpLg==,iv:K1wnGoCwMMWJ2Nn4ryqIj7UEwpyyo8bb1FxI1hpillI=,tag:n+FMbSzlaP6eJX6YI4ytrQ==,type:str]
+    REDIS_URL: ENC[AES256_GCM,data:NaNLS3iR6gjJ0+PhFQNTdw4e1rYd/lutyreqqg5ACJBymm8XvR0pwXVz8M2fHHdu5a8IKYw=,iv:oGO3KEjzIa70QQ7VXXGut1OaVUK8qDQgWopqxFz62cY=,tag:p3n0BwRIlWGpQ3mCBHQPuw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -16,14 +16,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJTkFyWVlteGVMS1luaitO
-            QzhFRTAwbnpNcTBVWXA3aWlRRmNRcS84bXlFCldDR29BaWdJR0crampLSXo4QnYy
-            dmZ4b1pPQkFvMkNZSjhvci9OTzJMTFUKLS0tIEJ2NjBCeFM3YXd1Z2Mvd0tzWkZM
-            ZmdBcHY4cXFOZ3BDUkY1NVNqSkkzS3cKyjpYRhwMCcklzaITQl/2iTRCjAYzQo3m
-            uHdBNZvsMTcZ6UsFCUQWduaPwJ1GhDNOcsqZmYzXKfEbYTKa9UIxCQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0RGlIdU5tSWM1RlI1NzNt
+            SWxoL3pIMzZta0g5M3czdWhYQy9FUmlkYXcwCkc1V0F1WjhyckxnNkUzR3ZsYnR5
+            RlBBNjVJYzc1M1E0ZXF3eVVvTnVNZ1kKLS0tICtaMFZPdWFDTDc0WkE2U3VxUEM4
+            VDRjTDlUdktFTGpIZXBYdVJGQzhNdzQKOzY0fBA6IcYNUdNKK1uBlce9GK7wUZKX
+            p6MIJs80KHNbOnavhdT0moqw7gWi2209IwGtMhXPHeMjiAeJDpGAzA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-02-20T18:32:31Z"
-    mac: ENC[AES256_GCM,data:I2BIrrpjrUB1tGBWi+ptXax9kZ2VZK5GKwMjCUKaNfCYSbJOPr4pFwz/Ix5suE8/oY0KMJDkBT+Q8tikaRJBvsQYXhQW2GK0YB29LvIu4Yq9c3rLRRilu7xt2JTD71E4e6BewgDtayVscz94frn3Ojkzzja2tQgeJ6II9nfBnfo=,iv:7ieW/kRtRJh44etiJWMPX/Pa1F+d7UJTWh4wQuH8Dbo=,tag:I7u+ACEqMD7o8QdfIZ2L1g==,type:str]
+    lastmodified: "2025-04-22T12:31:37Z"
+    mac: ENC[AES256_GCM,data:6We0IVaSoczfk+Zip+Tq62Jg/esAw63Ny7PPiMUC1L6YqMfoH+KzqXASM/+fb5/jfNG2wLMQEertNCwocFVn/j+PVqYFnrtAOKbgJ7GJ6JJQ7XszferTdl9y/K+CDBdFdiGRTVMfR638n00bTaiP090+HauUTB/emQzBbywVtiQ=,iv:qLs5hSum3frV1TdI7608yjkDLZjtD20yBZlESVMhMqY=,tag:W/A4p9WfMzDQ3YDHRWjHNw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.9.0

--- a/kubernetes/apps/media/jellyseerr/app/jellyseerr.sops.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/jellyseerr.sops.yaml
@@ -6,11 +6,11 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    DB_TYPE: ENC[AES256_GCM,data:NYSQDrRrLj0=,iv:ZH3a8kkXAC40Zf+PasmryYlJdqwgOBDZaq7c4b7bsCg=,tag:d0b4Dhzxl9A4+LcbzpUYvg==,type:str]
-    DB_HOST: ENC[AES256_GCM,data:sG46906lRM9rQWbpjWMyMhmXELd0A/sbqRvzrEvz7xDt5pQ/4L0=,iv:Nml1ysNxGoNnKfiBy6fOSuI3+mVWNIUxxgOD2dshVvk=,tag:V7kYLhgUSEKZ8BISt08T3g==,type:str]
-    DB_PORT: ENC[AES256_GCM,data:raB/zA==,iv:M7yoTPqepKzEnRvJQoTvqCXLrDF3KGxb4c/SuaWk7CI=,tag:rr2sLGUwQ3jl5MJGXF+qww==,type:str]
-    DB_USER: ENC[AES256_GCM,data:eYfAw99DZkdmtw==,iv:H51HyQVaquEKRzbKqZHVKDl3k7XEZqLT14zJ2oGivXE=,tag:uCYlsB6owMqFvlZuVHUdng==,type:str]
-    DB_PASSWORD: ENC[AES256_GCM,data:GH/Ss1+Oqb/hMQfhqU/4XI2Luno8zwWPsEiGG+xZYd0=,iv:sBRu2Qcb01HYh8hB2iSk3ERDGp3OvAvD0VnTBasqm/k=,tag:zTLcKUAcdrC3J2L5r1Z/hQ==,type:str]
+    DB_TYPE: ENC[AES256_GCM,data:q3pvN5/eqBw=,iv:NIgIKLO9XnPa8rrncTnHGJJXAKPTiqDBXiMRv5b0cQI=,tag:HrVx7N3VnxlUHVo/1cxhXQ==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:PbQJzWB1z/hTkQcgTwSvVaiw+CB2fqeHMNz6vsjfQH0qIeS0jWu/jA==,iv:jpq4AmSUOJcRl6RPlisJaI+c4K3f95FhPqR9vzqalj8=,tag:RbEAlubQW53AAu+kjtCEjA==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:qlJRhQ==,iv:cl4zNb/oowkbUydnENDp54EM4JgR2OVhLo7nRzvxXHQ=,tag:eQFSpqJ5jsC6HKryEO0JGw==,type:str]
+    DB_USER: ENC[AES256_GCM,data:DxvwNd1ra+vxrg==,iv:/s66BOjEtRkr594I7K2OJk/KKQBj68EXm39VDmvR1lU=,tag:IwItp8tsvooeRO62Q+MiDg==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:Sus46UKXiM6LmDUiPcr6tpbxhigUWK3hOW1M8L38aXw=,iv:Kbb2TBE8e726rlA7Qaj6wPZexiRyyJG6exq/vLH7UiA=,tag:DnHp9oZQAj4ih5pASFKpdg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,14 +20,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoRGdmVUFsejVWc214TGM2
-            dHpQTitJbFlNWWNzN08zOU9vT3BUd1EzblRVClhodnMzdzZ6STYwaG1jT0Fma3VU
-            TWVtS0t0QzltTjRWR0haSlFFajJaRFUKLS0tIEhoZUpFcXg5Sk1oSXArRG44Ulpa
-            MC92UWQ3cE1OTmxYaUVzSnEzZ1FZcEUKSRrOrbXTkgBWuct/41n+QGqXN63vTbPl
-            djPVZZ1G5qBV+HXdz/VfPuP7J4zG3ZXNnDMXnu++9lc77cqdXUHsdw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwZCs4K1NUY2pNWmplT0p6
+            dWFtczRWY24wekJGV3VUYWNQS0hmbXdUUVI4ClkyUytkRzdoeHVPUXgxNzVsQTd5
+            aFQ1U1BZclhIRzQwSGxxSmw2VHVnNXcKLS0tIEQrYklPYVp5SUZ1dHBEZ0N1M2FB
+            WjBra3NyN2VSNk56ZTJSaEpST1dFbDQKqHxhVFZbxBJm/06ceK+mZMSrZyA6nJIX
+            toxioWVVzYFGSkwhUv0iyrvgNHtVMOP5794Xjq61zRt5r/tNz0/Yyw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-17T15:32:30Z"
-    mac: ENC[AES256_GCM,data:CDJlvHW8SGOU7N5yFwaeCUdVMpVvQiNZiZaHoFPIXL4r9am5NfI6Hg11VgbB8362ha69mIkPHNTXVkzk278b6+JekyjvSZYcGO0UmV+qC/4lk3kOaJVjIOKxmU8Ro++a91pC1Jpbg7kqKqiTj5J6j0c30MLKJB7dO+3oJ2h+N0k=,iv:QnKUdD+//+Lp0YySrx2WnsQdJdlDsjL+b45eIqMDD0E=,tag:zHvQgD0IUJMPXcHQ3ssAEg==,type:str]
+    lastmodified: "2025-04-22T12:37:25Z"
+    mac: ENC[AES256_GCM,data:x3v7JL/uFS0h8Ohw5j3bc6yXHJfwqY3iTQgrbFHYOf0S29kZU3u7QFiMnvja2JxM2To24dc11XZDBmUKEVoNUYMmP3sABrwMlrrttuQWpSc9SOmkgBmTQQFm/sV/SCdum4fZWkn9EouzSNIYcuFUuRMNVzk8CdORt04WfObGiFo=,iv:KVzTSJ4lZEg08NMah2UgvCyKji3sgmbEj4lJ13WFe94=,tag:hF/5qPiOQjYpOgBAg+kZfw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.9.0

--- a/kubernetes/apps/media/prowlarr/app/prowlarr.sops.yaml
+++ b/kubernetes/apps/media/prowlarr/app/prowlarr.sops.yaml
@@ -6,18 +6,18 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    PROWLARR__AUTH__APIKEY: ENC[AES256_GCM,data:tDlJ3gC1UZbWid+PHiWl0IzIHUfwcPT6ENRp7kGu7Z4=,iv:PMxH7OZYIfnW9Mk/7NoB9W8LUcVhXHO/TtdZBbiVIok=,tag:SCqJSmh80BhME7AQ3QSxqw==,type:str]
-    PROWLARR__POSTGRES__HOST: ENC[AES256_GCM,data:RH3+eeO6Zd4PiMdhDdz07/Qx3FChKgi55Nnh5U0zlXAZ5Sn3x4A=,iv:Q1OpbC5zZxlCA91ZLA/acyLoB+wtrQaDtgeogXqV1BE=,tag:pNIIGRYUXmxcYDkJawScgw==,type:str]
-    PROWLARR__POSTGRES__PORT: ENC[AES256_GCM,data:RG3VLw==,iv:VeLeORuHTTUvTtTML88jpAbLiEM3FAiJ0F7l/oF5pxk=,tag:oAgFyi5xrba3I+jrQvJJgw==,type:str]
-    PROWLARR__POSTGRES__USER: ENC[AES256_GCM,data:+yOQdJf3kyM=,iv:6jYtZ+Y3jI/Xj5gD3BVd4jJXNFBCcC+W9noXiVMw4rY=,tag:5EEYIsdhqcmTqwau3Vw2CQ==,type:str]
-    PROWLARR__POSTGRES__PASSWORD: ENC[AES256_GCM,data:IugPUXJWpbHj0e4V1GFXlOFRuo2PZwaozZlraaw4m+8=,iv:Sx8rlJtCl3NhcfKEe8QVBPqgsHZhkOCaftLp8Fii0G8=,tag:C4GuZ6Ycm434lg6lBHhRlQ==,type:str]
-    PROWLARR__POSTGRES__MAINDB: ENC[AES256_GCM,data:rA+a588aHoEHkDz/FA==,iv:xy3qN3sd2MR5TRZhlowFu6OXT90Y4rFe/4S2Ak271I0=,tag:vfCDtBzd2EVUoHTin5121Q==,type:str]
-    #ENC[AES256_GCM,data:R/7NQ63RQNzqxNxOtdQ=,iv:PJ/tzD6GrminnRNy/7qvFnoe0c1Cy07qlsLnTYSsE9k=,tag:NDSgzdyWW8Ld+Udc2qiGJw==,type:comment]
-    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:Gxxh0ooCsVAjIrToWQ==,iv:xfGWucq0dH7YLEl8eUMNbdC+rRfK14FRmWegJB7KR5Y=,tag:t+Wfuma9XYvBYD/XiLOryQ==,type:str]
-    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:YuJipTRNB5m6qFaB0dfdS2ALHdoELgAaniweCdBBGQ7Gdfvp62k=,iv:w1xVBYK9wF3aZGE2tFvFbTCxy+OUP3fMmEDIdfHtFJc=,tag:RxR6UlxVNlwDxFFVY55z/g==,type:str]
-    INIT_POSTGRES_USER: ENC[AES256_GCM,data:3k3UuJoE9MY=,iv:qi244SZvr2kY00Ffmk5Z8nBBfKLUn8m5oi1zDUWu0S4=,tag:/U28fEYd00UE+nIumOz0cQ==,type:str]
-    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:BsOG0VjJvYWzUIMvfVcXYLCbbemgAxfj0vnMBbLz86g=,iv:nTUhNK+apw8jbBZzEfRZ2hIsoylvFS3BygNkKBI5nhA=,tag:um60E9ccLlE3RSUeh/se8w==,type:str]
-    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:A+PYQzuAKDSzoJwjQFrtcw==,iv:+clO4xSVqNr0i6eRkf+e6ETMKYDIKFMEG81IJ7kxINo=,tag:2gPvar5jFRw9JNIQjWk+6g==,type:str]
+    PROWLARR__AUTH__APIKEY: ENC[AES256_GCM,data:xAbj2J5pv0lAH/x6YeSRMh98I7QuDW8stLIm5kyrF/I=,iv:AIUcELh78+u+2E4pODuEvstE2UDGsEJn2tiZOm+rKgc=,tag:Z8/nsLogjLImojgB4E/1MA==,type:str]
+    PROWLARR__POSTGRES__HOST: ENC[AES256_GCM,data:Oa20MP1jbwy68SB/+nJ5TVASUNaFMg2GDDR42OS1R0PlNs6Ia/C5KQ==,iv:rQYq3t8i8w6uEi29xUg4pQ+R7mnkHkKaxxwj0WpBZMU=,tag:vP33bHl/od0ZkXgkzXTHWA==,type:str]
+    PROWLARR__POSTGRES__PORT: ENC[AES256_GCM,data:VTRX0g==,iv:XvVDcFAO8I3zFcsZGEpbayrN14B8j7Ai9VcB313jG50=,tag:eL8UWPVILlRA8l5wHWbVkA==,type:str]
+    PROWLARR__POSTGRES__USER: ENC[AES256_GCM,data:FnKgoup9MSM=,iv:3qVzCuS+H2Ag3OxPQJHYSBsreiMoz+3JTt44YhPynqw=,tag:upySL/+YZ8XRGpxFfBUC2w==,type:str]
+    PROWLARR__POSTGRES__PASSWORD: ENC[AES256_GCM,data:wjQejhIDSTzCMl4Q9BGKVXQ6yokV+3gr80/i1asOjtk=,iv:PivauLVqwFxBhxtJKc2scFqQSwldeDoGTUJbfVwCkV8=,tag:QaGp5gxlWcPOL/S9+F+/sg==,type:str]
+    PROWLARR__POSTGRES__MAINDB: ENC[AES256_GCM,data:l8FXCNy9AJTjG8vwnw==,iv:fteu7i/Ss3I4sNXrmL3pu0WfB4qLXUYOMP55jHceT1c=,tag:jotf2qLBRTcmR83EHblC/w==,type:str]
+    #ENC[AES256_GCM,data:aBG+9/f68YpXwTduf8g=,iv:uk7Pz16IPnEGmgT12AvPOmnhOqmSjsrzDiRNzTvozJw=,tag:f5bxiKxV4E2VmOqMR3fnqA==,type:comment]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:Dqn0MuPXV5uviWPG8w==,iv:xBRJ9vYepMI3KG7uTPSB6Zjohs7+TRcHwWQjtM4rTsI=,tag:6hGZk4v4LVuoloRH0w/neA==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:zUfe+XxrowaOVWVcYRrW91c7+s6aa2YcJgPE6cWa6SJn+TSUqe6m4Q==,iv:dD5omSy6bJk7cQ9pQV+ylkvqACyWcN6SDNe/c4kFQNU=,tag:9hVuYafAYRDB7pU0MRpLUQ==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:kG0bi5heyvk=,iv:yK8tjjHGnzNI1m7ReBTXO+yTCMBQleeGbQiKD487MHs=,tag:xTf8OK+y1qY8XAw1WeAHfw==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:p3jgxq2kAcZEUGEDokxrp22Om4LWFvTjZoZqyE/j/E0=,iv:RGapU6CGSb3is8KcYZgqQxfqIAmx9nXv9stsBaPMIgs=,tag:9Svsw7uQpqouRXIVNwitMg==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:UJcgPbUbGXfk9dvsMHz5BQ==,iv:37Tkmwzhgh4YfPPfLUTieqknABAn9MSKixhVSe4ivXM=,tag:V+vczY27tld9zE/7qmTfnA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -27,14 +27,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMWk1pOEtpM01yVUhlZFJO
-            WTRLc0h4Z2RobXQvOEFVUm45b2pTT1R4VVZFCm9QamhDRkMzOWpuWklGYWgzVTdh
-            YjFwZ2FEWWlSODg4R0pWa29jY2wwVFUKLS0tIG9SQVNadmFtYWppOWJvNEpFeGFq
-            bGlwNEIwUFBsLzhxZnJja1Q2UEU1ck0KXxxtpS/d6XZM19HgHqQNqHtHpWT5KVW4
-            BamH1QwMSrAzhHiLytXzSub+FG64GMUcAhDt7oAgEcS5ZpsjvRleGw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKYm95ZFV1MU4xMFFJNTZn
+            dnMxUUNDbGxINUFPY2R3UTlqaEVneHpKYXpBClZKeWdLNmxiazVyWERrOURuN0ZT
+            YkI2NDlNUEV6NDhPaTk2OVZEUDd1ZDAKLS0tIGhFdnAzUXRoUEphSTc1R2ZSeVVo
+            VmRGeitKMUpiRmVtYjhsSE1EMkp2ZVkKU00Lg2Ilgwd3gDy/tu9QAA2LlPGscsfq
+            lqymord4g/V/G4I4S91RE9L3rKesCyjknS5wOjvVWmLCeLuzGelLCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-07-15T19:10:10Z"
-    mac: ENC[AES256_GCM,data:wmrll/3bv4XBjlcII41L/u62VvcSAqExyyg+G+3SdYmP3mqN2jRzhlBrvh6M5E0bnprMejROq7u+tuzC9Uy4aCDBLs39c5ZCpZnv2zNnauDZ9GVAC5MsZqqU/SPpUvsqj9qI5H5FR95f3/3bdCAzVvRRh3UQPsFjPK9DsLRjlm8=,iv:zsgrYT+Ke6jLmonYHahcEXWmWc8DJVikNPDo0UbuTZY=,tag:a5TnS9EDiO71op14XzpEeQ==,type:str]
+    lastmodified: "2025-04-22T12:32:06Z"
+    mac: ENC[AES256_GCM,data:lGxCmE7SgS1Z5CCg481T4phBWYWFIj+SMUc6jBv8pKXyR12LqrCX7AXpyhitSiOSAE1jboBiHlBUBv/nTY31XC3yYlQpvoABYJ34uHEHfp1L2Le4YLpiyHfXQfq7X0jz8C0PeZrx1AFZSnsarb38x3FJ6EjYkijiVRJeqPeNwYQ=,iv:HO0SVefWsGXKGZ58PSDiZPG3qdYvYgviJuZQ86QEwjM=,tag:MYspPD/4GwxkthHwkH8+uQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.9.0

--- a/kubernetes/apps/media/radarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/radarr/app/secret.sops.yaml
@@ -5,19 +5,19 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    RADARR__API_KEY: ENC[AES256_GCM,data:OPSarBkiHk1V1yTxh+CaOSe8S2vzhuU40t0N3DDeulw=,iv:s6zjthx9L2Mb5b6l7KMhMVor6S/36jRYgP7YBS1l3tg=,tag:dT1rzlPDR7GmLAWXk/tyEw==,type:str]
-    RADARR__POSTGRES_HOST: ENC[AES256_GCM,data:Bsh5bjwLI4ad2G2oW8p6lN416YYJZ+8y3PyNqNEKUiYSLPJAG1c=,iv:MwtelSqys6y7QytR0EfdbNMTVBb+k96tIlENbIl1uzM=,tag:PQQoEYzr71rGAc2KwXBb+g==,type:str]
-    RADARR__POSTGRES_PORT: ENC[AES256_GCM,data:kSRzfQ==,iv:taTKQvyg5fbcsUf8HpGWMJeawHRppsJf/R7w63qexY8=,tag:yJ7WJQV8HOEOa7prP1nD+w==,type:str]
-    RADARR__POSTGRES_USER: ENC[AES256_GCM,data:parTSrjb,iv:bYqOZa5ASBjgk2O8e1RGUGhtRmkmulojbhgMzR+6iCw=,tag:O0rYKNW5yx1a6rCxmxNvfw==,type:str]
-    RADARR__POSTGRES_PASSWORD: ENC[AES256_GCM,data:ZhWGN6RMFXCBiyqJc3RfYurzl2NYs4r10x4zR40WUSU=,iv:NLh0IQ7mk9sfLjEzEnrLM85sS9EmpCkPiB+fcVxatsM=,tag:gT08xFaD4lZj4B62fCzW8A==,type:str]
-    RADARR__POSTGRES_MAIN_DB: ENC[AES256_GCM,data:MadM+xjGKCPOLho=,iv:kN9GQJml8Ir7aF3Onfdm84EHJn4bkeZtP+sXKdJEfYQ=,tag:8JQ2RK1ga9cJWWTePIu4pg==,type:str]
-    RADARR__POSTGRES_LOG_DB: ENC[AES256_GCM,data:GAtuJrEeUOtBdQ==,iv:X4azdlvebCxUY7asatQwecIP6LwKMen/TADxeoxRbYI=,tag:DN/JZCkhx0fCAW9LMvTwFQ==,type:str]
-    #ENC[AES256_GCM,data:n+9X8OFxAY0Iuw87Pt0=,iv:fJg8R/csghaPb/P+eHERwaXi3AVt1SM066uoc4zQ+7s=,tag:nTY5aiXX8ov6htyhD6HwIA==,type:comment]
-    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:VY7dHVFJEGSmZeaOGpa86Lj9WMTyPg==,iv:2no/avhVu39WCsgwh5A2KODzzL1jdc6MpTy9j6x5Xhc=,tag:2qwYSrD3iSWO4aqBDNizfA==,type:str]
-    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:A6On8pn7+tYNDqzaKrBPz+DbaXkEnNgMR2qKyq8kLF14eyeGfI4=,iv:TtPViU7fFQExT3Ok3D6JUeOYQd/MO5nEoBJuSKfhSoE=,tag:bun1EiQlPkt+QYK+IbcrnA==,type:str]
-    INIT_POSTGRES_USER: ENC[AES256_GCM,data:FiCfXugV,iv:IoDyRaPyhbdrv3RS1iFG/IZ2mZTNVG1I+IXzvVHzf1M=,tag:k1tX7vHpnTThUgvwZBFATg==,type:str]
-    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:2KZbSsSHMKHiVhJStI8/IqpyRgD5xGM3JLbdwe3QJlQ=,iv:HB/pV3+fXgxqwzydzh7c0GHoIoz+KQgNEWoaCEeblXA=,tag:pavJZ7vlDiO1/OQQqWBLow==,type:str]
-    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:HoojM4g/L47Zp6kxOdcVlg==,iv:1poXjrJVZQc9N+D9/610V3F1C64kS9vYxBVmRPuRXkU=,tag:jJMgr2eu9apJfr4PslocpQ==,type:str]
+    RADARR__API_KEY: ENC[AES256_GCM,data:0yOSlY1vUwgXI0bmbLJglQCKdWrAuwiYvMzV21ZR9X0=,iv:qRtDnSdPut7t+z34w0OewxMFfppIxuQqsugTJp0mMrk=,tag:HbtJDJ1QRKwFMvu+N6KUgQ==,type:str]
+    RADARR__POSTGRES_HOST: ENC[AES256_GCM,data:QRt4MP7A0JWSmE139gXZROcIz3Jr7rlig+M2lTB6gmkLiKhRsBOe9Q==,iv:HLpopGBAYhS33w/nkpoj3A/vvfEjUxtisraomHHF7k0=,tag:nIrERbp7ZGylMdT50BP63A==,type:str]
+    RADARR__POSTGRES_PORT: ENC[AES256_GCM,data:vij1Ew==,iv:eH6lQwywcMS62xl82KhSIrgV9oEuCQe8itOsRzOk2QQ=,tag:VUrKZ0cXwE1SMJRPYt4NDA==,type:str]
+    RADARR__POSTGRES_USER: ENC[AES256_GCM,data:y+h6ngsk,iv:kPFZb8sMKAhAeDuyg9CP+9hFQZmrV8+VWXRaa7KWN8w=,tag:iPKv2inW3XYLY0U+42HSWw==,type:str]
+    RADARR__POSTGRES_PASSWORD: ENC[AES256_GCM,data:vIUuclX1WRzYbltPCh7Erwc2+z1OIVG0P3HyVfjt/8g=,iv:VQImYAOv3nJX32EAellf6yNKpFSMdmvDszKCWOxb7h4=,tag:Tgd/lCQiy+Q1UchqHv9gIQ==,type:str]
+    RADARR__POSTGRES_MAIN_DB: ENC[AES256_GCM,data:yxl3H9VQ7dCusjk=,iv:Gm7Nki/htIvjbD2VpRuwaRl4MuTu7PPTIGKja8p3oMI=,tag:34ggpdWp3kkDyeiMuUqVUQ==,type:str]
+    RADARR__POSTGRES_LOG_DB: ENC[AES256_GCM,data:Bt7faAPXvalAAg==,iv:B0bywnoxlDiAhmeoKAMUqlNRF7wLVKSRkfugRmiN/Tc=,tag:yLf/JlWPJpJvaAEaBY37lQ==,type:str]
+    #ENC[AES256_GCM,data:fJkNCkJAZwlO3Do1T9w=,iv:wViJx537tYp99niIWtoD4GCF9HLq7utbaGm6NLpdyRg=,tag:nU0iaFlYY0PqHTFEfef4UQ==,type:comment]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:NZVLJMU+pqdmK4IrikBUxjeONwFYiA==,iv:QAUNlJQSiDOx46qjTIM3SdqUiYVwjnjgxhg+67bkIIg=,tag:/nF51wTlqB+xuxsBImEOrw==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:vyu8aHJTQlWSac7vKy9KLX54LO4axft8u0QKNuPANcx4X6VYwlXFVQ==,iv:Sqj11dBg/zxWairJJUsojFOZbpe30Qq3tKPiJnVYL5c=,tag:EKx3Skop4rSdqxrEUZt7pQ==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:v/rEWYbv,iv:z3aFnCVORnhifsqgVjYI1hTkKVDjCDhsLbmpLSj5yow=,tag:PxJwyydeLVYOspOqNhaI8Q==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:hw3xsocCKsNWHRv2YLo6uJidmaqyBzEsaLNZITXcNDs=,iv:z8Lr9QmSjw5jZRSbvR6lYZ6mL20HpnNz9qFZhnLGKnA=,tag:IZ9buN3XoI/MHZRhe1fLaw==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:PLLBZZDpCD1UXBQTlYb33A==,iv:f3OwhSOtteZRpRBhrrHWLqqB4lMUwsqvcl6yAz6n9Do=,tag:6xoFD/lvteN9TkMZ8Swu7w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -27,14 +27,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoMVFQTnBpcWthYk5CYXg1
-            dDBqT1RjWGRCYy92dDdGZTJYajZMZlZVMURFCm1zS3NFZHd5NVBjNC8rVDcxYStr
-            YXE0TnZLRW1rNW4wUjM2NG9FemUrZ3MKLS0tIFh6VWtPY0FiVDRZTzFBc3JFRUE4
-            UkMySlRhTFRkSnlwTnMybDlZdEhQd1EKVtIj2I30FT6yN5uviWU1/B2PLZt5EuJG
-            T1qiHCgKzupzS5Ybk1vDHRdldIwhx7BtX+EXPyqLNkw1dbdjtfq3xg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlbzROQnRmYUplbTAxZzk4
+            K2hQWk9PUzBQbW5ZdGlZT0NiWjZmbzg1RUJVCjQ4d1FZQitTU0JIRTY2bUlET2Fa
+            ZVFaL04vNk81ODFEV2FVWHJUWjhtbXMKLS0tIHB4QUswQ0VtMDRMeUEwMk5wa1FZ
+            Q2o1Wis0Y0ltZ0lNSHZlQW5kOFpHVVkK5A9jIY7SgMtzgY1ovHZ8DWn9NLCiBJtQ
+            M/thG4u6aSprVPSr7Ia7vK8zHLBxe6Zm/GijE0k9jEpynR+ze0losw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-05-29T08:44:01Z"
-    mac: ENC[AES256_GCM,data:fJVE7ksrfgn93zQylzQw6FDsGhIX1Xs5+Tgyjtyt6Kh3OtdtJC8rWM2aDHcxod5Cin6hiIFsNHkVxWOI0jex4uG8jgtqmfY78WslbQpUlsrPG1jhfATEWT3UCh8gwZTzmcktoB33pW371JStWpeap/G2cXjH9wttPaeax0JnVFM=,iv:nti4Uf9e+TbOF/bERw93e9g4NQCya5uFSWk0ePvEOgc=,tag:nRezBWxxAKpHjaKvVvjdbQ==,type:str]
+    lastmodified: "2025-04-22T12:32:23Z"
+    mac: ENC[AES256_GCM,data:IDW535cJ1FWbjlE/vpud8Mu3LNTQc6jgSX9nlOkY7omSikE36nfn+/tdmwX0AtXAezoLSonxEQXSdrx1DoqfhmLiftANCehWQ0u7JGJrFWQl4WmeTyyqAdMtRXm0KiA79RH4FvqjibojU3YNAOkPEO0uUfEML8mVkvhU2bk8rBM=,iv:Yzd+5EWYq7lPL20IkPJntqUQ8a7EVk+pmWDlbAYW1qY=,tag:gVpk52LoH60+Ml9ZavS8mQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.9.0

--- a/kubernetes/apps/media/sonarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/sonarr/app/secret.sops.yaml
@@ -5,19 +5,19 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    SONARR__API_KEY: ENC[AES256_GCM,data:GpnO8+J4q6v2V1ylruUltX7uX1BqQOAMSrbXFSR6AZk=,iv:bq6vyUpF/TQtjOsdh4QGxJYShz+3lbOelUBEP2cVH5w=,tag:J0yboNErbA0YCAKUiD0pkQ==,type:str]
-    SONARR__POSTGRES_HOST: ENC[AES256_GCM,data:ZNkich9Tqwp5JpDYFZbgRDlKYdm/sz5gwyQa3WNbE9Ho4rP8znE=,iv:brITrLqh+/YcwkSUsQy775Tegp8bGGjX33WmShyqB7Q=,tag:IEEVQOZRequaapYlBNBVOg==,type:str]
-    SONARR__POSTGRES_PORT: ENC[AES256_GCM,data:2HlrSQ==,iv:jDbScpG1UfY++0J6Pa6nmhsgCJgcxWkMuKu2wYDFUK4=,tag:ExCRAfUbS1IATYlZfIeCMw==,type:str]
-    SONARR__POSTGRES_USER: ENC[AES256_GCM,data:5QOIaFMh,iv:wxdHJL9OJXPUafPwHYykip6e4CPS/G9HNtgF+n144gA=,tag:zBNCSk++pLpOgscWRLUKtw==,type:str]
-    SONARR__POSTGRES_PASSWORD: ENC[AES256_GCM,data:DlUJWyVEZPA/wFPe/KZD5eN294gWgRcYchUBBfYQOD4=,iv:h3gC85e0kipNktzxtJLeff8WEB1xiHB2fg00JGrTGS4=,tag:xigHbQRK0Y1G1KfAHudPoQ==,type:str]
-    SONARR__POSTGRES_MAIN_DB: ENC[AES256_GCM,data:8Djco8bCpMg1jpg=,iv:2IeN/rwKkXDWYdTsZkgaWw2aLokfMxGNk+zpJaNeGeU=,tag:RZJyuKs+jtiYRZnrRcpXhA==,type:str]
-    SONARR__POSTGRES_LOG_DB: ENC[AES256_GCM,data:BLTlrBHk4rdotg==,iv:Hp4WDLQQQX9MmQRxevFOj7XFfEtf5U/2R28SYVcVBrg=,tag:V+dEZFlbFqgEAya1K8Bx3A==,type:str]
-    #ENC[AES256_GCM,data:/d4KeRenryTduzGhaFc=,iv:kFEXC4WBJBWL5FKGbhZ1q8muxKVBWM3j79tPH8zjhvo=,tag:0KGOA9CAObVfKpYnDZxqig==,type:comment]
-    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:tIZTHiN1rcS4uTrHrvqFbbIjShdBYQ==,iv:svozDLGaqaE1lziYJRwU8t6qpsuo+5e7/rmyzQ0SUxU=,tag:YSyale7Npk7pxFk5axVLiQ==,type:str]
-    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:D/ANGjmlxB7ZKPnaGH5ejdTKTmOydo2lqalAgzq5bjs8jqJ1I0U=,iv:VcIKo5+paEvsF+9HTRw2m0kX+kX7gZKrgM5AvFWvinM=,tag:yl2Ls1+XRmTT9hnQvVwXNA==,type:str]
-    INIT_POSTGRES_USER: ENC[AES256_GCM,data:7a4ypD8/,iv:2DBFmU7VxVK/yFrGCN1RLFye/ilYVTB+L7MraFFgRGs=,tag:o2XF+dbr4Jc8WY9El/mlHA==,type:str]
-    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:UCHtUEJbBI1ljAB784CoZ00+kmuuUCBefEEhB2ByZvs=,iv:RuMr16EloGfIPulnwiGT8tcUvWB9axm/CnNtPwW5EhY=,tag:DAMuzqgcuBlBoY8Fn9rcDA==,type:str]
-    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:htci3YnlpI/tGKS4SFqEaA==,iv:Hk/zslLNfayVsfn/luiJpmbKcf+/X9yKlvQfvFfbqYk=,tag:dzGA2nCLW9Nm8uj+0i90ow==,type:str]
+    SONARR__API_KEY: ENC[AES256_GCM,data:N5qhb8KDSP39aY+eoCJn+Aku8Tl2F0M5hxpi3/vY32w=,iv:aueSmhQdzbuq54p61LAvbr0+1nVrM3kOgWrYTUzzf8o=,tag:AQTq3IcgG5rI7N/Znr2YzA==,type:str]
+    SONARR__POSTGRES_HOST: ENC[AES256_GCM,data:tPEBwjAt7BlhY1fYn/MqcYfHGpUXMzySdRd/FUKgVh5HepGAOFkDnw==,iv:JBB36c5CgmpPBcn/o8r7zenEv2uViF9uWmEll01wgcA=,tag:8XZFLgxzC8Z2gThiFgVuqw==,type:str]
+    SONARR__POSTGRES_PORT: ENC[AES256_GCM,data:86WPHA==,iv:E1OU+DZ7ewubpWTU6jOpa31X4z0kiZsDNbGIsZhCcjo=,tag:T3+5rvoIEm+PPHV1cEbj5g==,type:str]
+    SONARR__POSTGRES_USER: ENC[AES256_GCM,data:vy+c00WC,iv:WQ/KrGs4cEtMVKF/QRe2McgwQhg7cXox4otZB6IivXU=,tag:cOEeGpLmkVjT00n8onzmew==,type:str]
+    SONARR__POSTGRES_PASSWORD: ENC[AES256_GCM,data:UDMvs8JfFjhr82Ie9HkvdkyPuPt556RmLY6HAAAHohQ=,iv:mlu47YUsYQqyvZZ+5kzVQSfxk9a87N/Wfxzt4gs0Res=,tag:LPMHY6YpshADb5uafsjISQ==,type:str]
+    SONARR__POSTGRES_MAIN_DB: ENC[AES256_GCM,data:nQHg5m/9i537wT8=,iv:iHdgtQIpfR2c0eTgan/gUOraaLPvjMXlLPSsKSHm/6k=,tag:0TBNZGYRe/uAv8OuyQL7fg==,type:str]
+    SONARR__POSTGRES_LOG_DB: ENC[AES256_GCM,data:4OWX+SY8lLClAQ==,iv:gK0eh4YS9TdhgxCB/2GG6KOXr/wJOIWHeB9omiJeyvk=,tag:Xdn/+OvnyL5o7WLbmaKtkQ==,type:str]
+    #ENC[AES256_GCM,data:TnoNUKfnroz9OC3ebQE=,iv:X802it8r9SWMKE721YQrHbZQ1f2iCLl0vdrG14BOMSw=,tag:PvT5Z+HUlUy62OpYQPdwrQ==,type:comment]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:/W5Gftv/upOa7iWH4D/I5HXd1Mr+aw==,iv:i2oLh9i6kNPbzzTBhkyq/5QdhjCImyenXPTMlN/xPoo=,tag:PEd5JxXRXARvlFOZ/mwylw==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:MQUuB2TYkWytx9KOShsh2Omu4PPFhbbZ8CY6B9FVARpu5G9Vgkd5cQ==,iv:r93JiV6eU5E5g2BWigY3bOHKN3GecP1ZvxzH8eM1SNM=,tag:2lzt12OIL9Mv91hjV88Jog==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:lyFAoTP0,iv:Y1GncOhG6Xs8s2XhgRmwvOnAZ8PWAKCUB8xhfMfE5hk=,tag:rm+v0a+xTbFN4SBRN0cupg==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:pqz8k8CqKLNK7B22xKYTpJQnUDcStLSnFMA1i1wRpKY=,iv:lUJy6oFTNlNMCVm2qK8oIfbhWbgLrs8a2gKz5akiA2s=,tag:k5IiRjc6t1umVCsv+8RUGA==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:gyrLAL8qagIO8jl3yeVTOw==,iv:1KZFocFXs+xNhNaW/Zi0mq50MUFcSThVOH0PQeOEHUI=,tag:3JdV1+qo2c+aDzMgRcwyIg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -27,14 +27,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpbDhUdHg1bUdMMWpMSDFT
-            U1lFRFNxeFpPenNNNmtqaStFVWxkT1F3Mnd3CjZaVWY3V2xKQ3dxUFpvTlVSYzhE
-            aWhNUjh6bG00djlPRmt0aHpxREhFVHMKLS0tIGloaldEQ3ZQR29Pc3hJYklSNnRl
-            dEtQYy9XRTN3d1BpOG1ZdkpyNTFjcTAK58Vp4riDipRO5ST25eJtIYjAF0Wotl6E
-            XZ/xBCjHHUyzXnQa6nEOzHEaIRMPHsgF6D5MuRlhOgi2lHNQP5pg/g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVG9EZzN6ZHZiVFJmaTRz
+            aHJ3d1U5NnlUcFFIdUQ0QkxRM0JTMXBVTEhZCndoWmNGMXQ3NGhvdTRTSmpYbWdP
+            cHVxdjBSUHd5WVNzVHVPUVRvNUpBR1EKLS0tIEgyZjR4bHZwQ25ETjdTVjFjQnVs
+            NXlNM3RKTEVTSW9SZ0xKRUR6ZlQyWlkKh1TzV1iCitnQVgU5rBGCZ5zFlPpNyn3N
+            YOcRLeqrUURs1jI8Q+DCa2s7H//GvPI+op1VG6j9W5ClCcZp/0FiWg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-29T16:37:52Z"
-    mac: ENC[AES256_GCM,data:X3DpAgaMftI45nE1f/0ErkIQPE7RVZRnas28iOxwyISZ+Dlc1XdLnk0Q4tvUvrx2JK/ZVDraV1chf2l3TPzYl8QD0Mag+ItZadB4+Sr6yCiQuFN9t+cjBnM0pBD3qLDD7NluclUELHnUuraiwS+T2KTP+7OuqE6fUgT+QdJh/v0=,iv:9afDZ9AjW41LuMvtrw0fOa9TCD9L8vOyfLD2jT/V878=,tag:7fQuhIIa7QqhURNZWQTp0w==,type:str]
+    lastmodified: "2025-04-22T12:32:37Z"
+    mac: ENC[AES256_GCM,data:a2mmOOIwtyCtjGuKLdse9hjttGWcTAOkbMbRHpjEUD6XC8lSSd07TLFtHcLZYKIri7mfWXdMB5nZfgR2ZKPw+lklFJkw2Qq2WWBTm+TMfW+GUHmEnkyiC9A2F6TUimhkcQlxt240CmQRD7vIqUpBngg4uEVIGxdQjOS/cEzuU+U=,iv:IK2TwLmmq1y6V1fk5LNu7mcvUJCRhUxbyrZLADYrdSk=,tag:/zsPTSczMwj4zvJEzHYWmA==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.9.0


### PR DESCRIPTION
This commit updates the postgres hostnames in various application secrets to point to the new postgresql-17 instance.

This change is necessary to ensure that all applications are connecting to the correct database server after the upgrade.

The following applications were updated:

- immich
- umami
- radarr
- sonarr
- jellyseerr