### PR TITLE
 feat(postgres): disable password files for postgres

### DIFF
--- a/kubernetes/apps/databases/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/postgres/app/helmrelease.yaml
@@ -34,6 +34,9 @@ spec:
           database: main
       security:
         allowInsecureImages: true
+    ## Disable due to: https://github.com/bitnami/charts/issues/32959
+    auth:
+      usePasswordFiles: false
     image:
       registry: ghcr.io
       repository: thiagoalmeidasa/bitnami-postgres-pgvecto-rs


### PR DESCRIPTION
 Disables the use of password files for the postgres helm release due to
 a known issue with Bitnami charts
 (https://github.com/bitnami/charts/issues/32959). This prevents
 the backup cronjob to work.