### PR TITLE
feat(pre-commit-hooks): update flux-check-hook to v0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
           - --config-file
           - .yamllint.yaml
         id: yamllint
-  - repo: https://github.com/dahvo13/flux-check-hook
-    rev: d42a28ee0eaca65773109526b2444c0f4af6c6a5
+  - repo: https://github.com/tarioch/flux-check-hook
+    rev: v0.8.0
     hooks:
       - id: check-flux-helm-values
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Helm on OCI is implemented now on the original repo.