### PR TITLE
feat(hajimari): add app name and info to jellyseerr and remove prowlarr icon

### DIFF
--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
         annotations:
           nginx.ingress.kubernetes.io/whitelist-source-range: ${LOCAL_SUBNETS}
           hajimari.io/enable: "true"
+          hajimari.io/appName: "Jellyseerr"
+          hajimari.io/info: "Jellyfin media request"
         hosts:
           - host: &host requests.${SECRET_DOMAIN}
             paths:

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -88,7 +88,6 @@ spec:
         annotations:
           nginx.ingress.kubernetes.io/whitelist-source-range: ${LOCAL_SUBNETS}
           hajimari.io/enable: "true"
-          hajimari.io/icon: simple-icons:prowlarr
         className: nginx
         hosts:
           - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"


### PR DESCRIPTION
Adds `appName` and `info` annotations to Jellyseerr's HelmRelease for better Hajimari integration.
Removes the unnecessary `icon` annotation from Prowlarr. This improves the overall organization and clarity within the Hajimari dashboard.