### PR TITLE
feat(storage): add kopia as backup solution

### DIFF
--- a/kubernetes/apps/storage/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/kopia/app/helmrelease.yaml
@@ -1,0 +1,144 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopia
+  namespace: storage
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      kopia:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/kopia/kopia
+              tag: 0.19.0@sha256:615b786bdb46d5a9301338983e8077e5be0f1c643b7a3188c8732989104accf4
+            env:
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: kopia-secret
+            args:
+              - server
+              - start
+              - --insecure
+              - --address
+              - 0.0.0.0:80
+              - --override-hostname
+              - kopia.${SECRET_DOMAIN}
+              - --override-username
+              - thiago
+              - --without-password
+              - --metrics-listen-addr
+              - 0.0.0.0:8080
+              - --config-file
+              - /app/config/repository.config
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: kopia
+        ports:
+          http:
+            port: 80
+          metrics:
+            port: 8080
+    serviceMonitor:
+      app:
+        serviceName: kopia
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+    ingress:
+      main:
+        enabled: true
+        className: nginx
+        annotations:
+          nginx.ingress.kubernetes.io/whitelist-source-range: ${LOCAL_SUBNETS}
+          hajimari.io/enable: "true"
+        hosts:
+          - host: "{{ .Release.Name }}.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /app/config
+      config-file:
+        type: secret
+        name: kopia-repository-secret
+        globalMounts:
+          - path: /app/config/repository.config
+            subPath: repository.config
+            readOnly: true
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/cache
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/logs
+      nas:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: ${NFS_KUBERNETES}
+        globalMounts:
+          - path: /data
+            readOnly: true

--- a/kubernetes/apps/storage/kopia/app/kustomization.yaml
+++ b/kubernetes/apps/storage/kopia/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: storage
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/storage/kopia/app/secret.sops.yaml
+++ b/kubernetes/apps/storage/kopia/app/secret.sops.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kopia-repository-secret
+    namespace: storage
+type: Opaque
+stringData:
+    repository.config: ENC[AES256_GCM,data:8QvQNOWw+8tUYPKrwd4i2MonB3RNulHCmEeAn1CzOc2Cu+qkdwMFvlUBB/bm9dBr7u5rMfMa41EK4wGe3nY0NB1hTKl6HIPYuFS8casQFsevIN9e7NsI+ezgu1fJ13HOvwsN/CPQdDOG2Nvn9lFyydmN3TRO8LvXn6F7zaV4fL9QVeEbaRsZdwIaapYo29NT/Vm1QlYJHMz2Osaf3IilfTgAxvY7W0FHGMmeZg4JWN7/oku8UBJzEh42t6u3tLnFg+kWfEqnZssnHSJWjsO+1DbcF1n5C/EfKTN+gfr3BUjdkGWp1xwUl2e48jINq6bIwW6MPMFq12CNtaHaq28rdIVrYlSCaP5K+fF3vxxQ+LI2ljIjXNgIPKHGxRRuFAoiG/lQF0xk+EgBgW0Dy8TDiT3s0vFVb7hVCQWiM7+4OVw8nlPeCB0KsSl9jj3A5dz6mzHJefhqa5JIGdw0xG+GDKRbA6YMDAmCdUIdxRHbDn2yuwIfQPaR75E/hsoYGLHaswBJLldEGOYEJkKaJwPVwX/4c8QyROvrkQJetCdJaFdrXawQkinz01u3PJl3+rqfGMyD8nd0lGBjTT+EfLxMquO3KgXbph7JDonYtVUThYJnibI4yHVsZetGyO20gH/9hNiKg5bvMfrHvrDHF00vIcolLNy6yfK/eXDYqW1USxesK9DeqMBae1utZFvu6gK6h+4U,iv:y29wcK+KjziBu6WRF0urz1KLgmBvD9UubkHGeGVqoFk=,tag:ZEPU1BVPH1vfWDLW0wuz+Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZ1FnaE9ROFdkR1FTYTla
+            L3oxeU5FcGRzZHV0T0ZMY1liUG1HNWx6UEFRCnN0dGhYNzk5bHdUU3NaVmhjZWxW
+            MkJYcThuSHU3dEEvZWZrcWo1bkFXZk0KLS0tIDhIZnFSUzFNUFFqRUlHL1FHT3lx
+            Y1orT2ZHdzY1cHIwVm4rWnhITXBuWG8KmwN+Nz+FOTZtNeEdWT+g7pIy8du1vJyG
+            gs2KvzeTcQ/k+bEET0sRFxpV8W/hsyvDFZP9sCHAgQmswnPWlkbe0w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-04-28T21:42:08Z"
+    mac: ENC[AES256_GCM,data:q1EhrLakmg2cdFXtTiR3cszHqLs4/PuwehXhFWfIks1dc/7QOsPdkiKAeR83Bj/FiRWXilPmKeBztcSCenOh4BDWuRDV6bKFKwNN/pDYMKo0ts3bWGLNOYSywnRjOhh3m/yP5JFAD/8Jwo2itZoUhdum/mYJvf6hLQIXmAtqQc8=,iv:JhkyWk+cgV+MTEII0ikyOzVH8r8E3Ps7n+Ws10R5fQE=,tag:lMPM3XiSY9aNXTjmtFeAaA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kopia-secret
+    namespace: storage
+type: Opaque
+stringData:
+    KOPIA_PASSWORD: ENC[AES256_GCM,data:pCvXHCgd4x4G3gASTysYrCvpu1Ens20Ujgp5xi+vfnI=,iv:KvBoCvjKmcymnHgrMyCCVS06CRcDDTJZS1b3TIAGLDM=,tag:lteGcQtCn5gwnyBdC8+/9g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZ1FnaE9ROFdkR1FTYTla
+            L3oxeU5FcGRzZHV0T0ZMY1liUG1HNWx6UEFRCnN0dGhYNzk5bHdUU3NaVmhjZWxW
+            MkJYcThuSHU3dEEvZWZrcWo1bkFXZk0KLS0tIDhIZnFSUzFNUFFqRUlHL1FHT3lx
+            Y1orT2ZHdzY1cHIwVm4rWnhITXBuWG8KmwN+Nz+FOTZtNeEdWT+g7pIy8du1vJyG
+            gs2KvzeTcQ/k+bEET0sRFxpV8W/hsyvDFZP9sCHAgQmswnPWlkbe0w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-04-28T21:42:08Z"
+    mac: ENC[AES256_GCM,data:q1EhrLakmg2cdFXtTiR3cszHqLs4/PuwehXhFWfIks1dc/7QOsPdkiKAeR83Bj/FiRWXilPmKeBztcSCenOh4BDWuRDV6bKFKwNN/pDYMKo0ts3bWGLNOYSywnRjOhh3m/yP5JFAD/8Jwo2itZoUhdum/mYJvf6hLQIXmAtqQc8=,iv:JhkyWk+cgV+MTEII0ikyOzVH8r8E3Ps7n+Ws10R5fQE=,tag:lMPM3XiSY9aNXTjmtFeAaA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.0

--- a/kubernetes/apps/storage/kopia/ks.yaml
+++ b/kubernetes/apps/storage/kopia/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopia
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/storage/kopia/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./minio/ks.yaml
+  - ./kopia/ks.yaml
   - ./longhorn/ks.yaml
+  - ./minio/ks.yaml

--- a/terraform/cloud-backups/nas-backup-bucket.tf
+++ b/terraform/cloud-backups/nas-backup-bucket.tf
@@ -8,3 +8,12 @@ resource "b2_bucket" "nas-backup-bucket" {
   }
 }
 
+resource "b2_bucket" "kopia-nas-backup-bucket" {
+  bucket_name = "kopia-home399-nas-backup-bucket"
+  bucket_type = "allPrivate"
+
+  default_server_side_encryption {
+    algorithm = "AES256"
+    mode      = "SSE-B2"
+  }
+}


### PR DESCRIPTION
This commit introduces a kopia-based backup solution for the NAS.

Key changes:

- Added a new Kustomization for kopia in `kubernetes/apps/storage/kopia`.
- Defined a HelmRelease for kopia deployment.
- Created necessary secrets for kopia configuration (repository config and password).
- Created a new B2 bucket for kopia backups.
- Configured the Kustomization to deploy kopia to the storage namespace.

This setup allows for efficient and secure backups of the NAS data to Backblaze B2.