### PR TITLE
feat(kopia): configure s3 storage and fix group ids

### DIFF
--- a/kubernetes/apps/storage/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/kopia/app/helmrelease.yaml
@@ -82,7 +82,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
-        supplementalGroups: [10000]
+        supplementalGroups: [1000]
         seccompProfile: { type: RuntimeDefault }
     service:
       app:

--- a/kubernetes/apps/storage/kopia/app/secret.sops.yaml
+++ b/kubernetes/apps/storage/kopia/app/secret.sops.yaml
@@ -5,7 +5,7 @@ metadata:
     namespace: storage
 type: Opaque
 stringData:
-    repository.config: ENC[AES256_GCM,data:8QvQNOWw+8tUYPKrwd4i2MonB3RNulHCmEeAn1CzOc2Cu+qkdwMFvlUBB/bm9dBr7u5rMfMa41EK4wGe3nY0NB1hTKl6HIPYuFS8casQFsevIN9e7NsI+ezgu1fJ13HOvwsN/CPQdDOG2Nvn9lFyydmN3TRO8LvXn6F7zaV4fL9QVeEbaRsZdwIaapYo29NT/Vm1QlYJHMz2Osaf3IilfTgAxvY7W0FHGMmeZg4JWN7/oku8UBJzEh42t6u3tLnFg+kWfEqnZssnHSJWjsO+1DbcF1n5C/EfKTN+gfr3BUjdkGWp1xwUl2e48jINq6bIwW6MPMFq12CNtaHaq28rdIVrYlSCaP5K+fF3vxxQ+LI2ljIjXNgIPKHGxRRuFAoiG/lQF0xk+EgBgW0Dy8TDiT3s0vFVb7hVCQWiM7+4OVw8nlPeCB0KsSl9jj3A5dz6mzHJefhqa5JIGdw0xG+GDKRbA6YMDAmCdUIdxRHbDn2yuwIfQPaR75E/hsoYGLHaswBJLldEGOYEJkKaJwPVwX/4c8QyROvrkQJetCdJaFdrXawQkinz01u3PJl3+rqfGMyD8nd0lGBjTT+EfLxMquO3KgXbph7JDonYtVUThYJnibI4yHVsZetGyO20gH/9hNiKg5bvMfrHvrDHF00vIcolLNy6yfK/eXDYqW1USxesK9DeqMBae1utZFvu6gK6h+4U,iv:y29wcK+KjziBu6WRF0urz1KLgmBvD9UubkHGeGVqoFk=,tag:ZEPU1BVPH1vfWDLW0wuz+Q==,type:str]
+    repository.config: ENC[AES256_GCM,data:RoPXv3C7+TY4XU+rndqzjUfQkJDlp9RUl+MGxpA5sb26djAKA2CvSLLWm1zAtSOhrd2IMXMayAutkvUnsVs8gYOnLNUp2u64VeIDsD1VJa2vU48LXN+yExqAaNLsz0iHXmWxu60JUbzGawS8OPtat8y+bZUlCtIsfTVUXt8jTo+M0e/vdtq782sMDEd3wWgZKPS6BPsel9vcuYJo++zo7wuRFDxMaAaohtauo1vxQOnkulJnzcvP64VN0+zEoRj3wYD0/090ZTf4NzZrAGdxhlLQUE7bL5K9p0CIx8VYsLRJsbhogNSjB7zti2XAMaTGQukgE0ZURYQCNVwr6wKHYBvUUwPiyGbN5kcjf+78BMA6Il+uKic4tGsxBB/HGaKBjNx2a0PtmD4WaAg22xZFMImr4/Y8fMO6NimNSM2LjI8BGMhw9lC+ner/jEb8mHgyx0i9OdAiBgqZLdv9aj/wvCJASinICrDRmFd4eaEimtWYp/wmlTcv2hsvN3LcJ6BSB063nByh4tpqBH0+KYmNppFbqht1yRhJ9bxKNSGcZZJVimpvVQEP7RXYMfdgbNVCJqQKraAEdb3stNAZoec02hPHyGQBKwAXZkp8jQ6FEDM5bO4MrVON11JwZMnA7SoZjJIxDoU+8kXivaWKJ23eu9u922EuWQHKIJWUcl+SdmGzVxPYdUQxIbFfS1kLuXQl8o4kTzrVcqvvk8t+vXZXKOHVObPTCTzrBOXbqHeZ1JA4eh9MuXxm+VBgt8kdRkHckQTAD7DhEwU7jNrob61Mu27fYLS4QCG/5I7gnw==,iv:gRgoRpv41UJk0stTM6Cn4wSczCB5XwwMbuY3Xd8I8Tg=,tag:Fdz5jCWXr6iWOMerj0LDog==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -15,14 +15,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZ1FnaE9ROFdkR1FTYTla
-            L3oxeU5FcGRzZHV0T0ZMY1liUG1HNWx6UEFRCnN0dGhYNzk5bHdUU3NaVmhjZWxW
-            MkJYcThuSHU3dEEvZWZrcWo1bkFXZk0KLS0tIDhIZnFSUzFNUFFqRUlHL1FHT3lx
-            Y1orT2ZHdzY1cHIwVm4rWnhITXBuWG8KmwN+Nz+FOTZtNeEdWT+g7pIy8du1vJyG
-            gs2KvzeTcQ/k+bEET0sRFxpV8W/hsyvDFZP9sCHAgQmswnPWlkbe0w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwNUVOLzhLZlVTQWMxMkJD
+            SkpxampiSXpqRCsrUEZuMHRCdG1oa3duZHg4Cjg3WWpYSXR4VVNESm53bU1sVG1K
+            dnlVdmY5L2pWQjBsZVF5OGNaSTRBd0kKLS0tIDU1SWt5TXlTNnFYS044NklMbUVo
+            MDV3V3NWNU1MVFg3cDM0enhYUnFHRFkKkdf7yxV+YeJHxY50L0TXRWA3BIMgkZF5
+            waLqYYF7TX4y0O0vwkV0fDUpZ67nCXb9+lu6GXMa7hnjlpzdNYFyPw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-28T21:42:08Z"
-    mac: ENC[AES256_GCM,data:q1EhrLakmg2cdFXtTiR3cszHqLs4/PuwehXhFWfIks1dc/7QOsPdkiKAeR83Bj/FiRWXilPmKeBztcSCenOh4BDWuRDV6bKFKwNN/pDYMKo0ts3bWGLNOYSywnRjOhh3m/yP5JFAD/8Jwo2itZoUhdum/mYJvf6hLQIXmAtqQc8=,iv:JhkyWk+cgV+MTEII0ikyOzVH8r8E3Ps7n+Ws10R5fQE=,tag:lMPM3XiSY9aNXTjmtFeAaA==,type:str]
+    lastmodified: "2025-04-29T08:32:24Z"
+    mac: ENC[AES256_GCM,data:Si6Ybx2dtWxPTEnCTgNhBkFJ5C3RLscPB8qrFu15SduanxW0WzzEIvIBy0aDC/8CvH1/E9/4Mid9vDdsajhOD1ki75+KAu4ucNXToeXQkCfpXXmCKij/DAPv/bydUnhdIAx5RdM8r49qOtDnV7na+miK9+9TElHIhKXIoWLK69U=,iv:NPaGNilXFDc9ZEh4Wc6zHlVtrMr0pG/KpJPB5pbo3r4=,tag:4VYu3wBbttwF6VH+W8Oh/A==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.9.0
@@ -34,7 +34,7 @@ metadata:
     namespace: storage
 type: Opaque
 stringData:
-    KOPIA_PASSWORD: ENC[AES256_GCM,data:pCvXHCgd4x4G3gASTysYrCvpu1Ens20Ujgp5xi+vfnI=,iv:KvBoCvjKmcymnHgrMyCCVS06CRcDDTJZS1b3TIAGLDM=,tag:lteGcQtCn5gwnyBdC8+/9g==,type:str]
+    KOPIA_PASSWORD: ENC[AES256_GCM,data:yHe8rLjYl7wFxMo5LgT1DaK+gdplx++FKhONWDRugI0=,iv:yhbWOrAx3tXEl3sJyavVzMjuPlEw/HxJu3/spAVFrbk=,tag:WbxCtSXI6ffxAljF7mX19A==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -44,14 +44,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZ1FnaE9ROFdkR1FTYTla
-            L3oxeU5FcGRzZHV0T0ZMY1liUG1HNWx6UEFRCnN0dGhYNzk5bHdUU3NaVmhjZWxW
-            MkJYcThuSHU3dEEvZWZrcWo1bkFXZk0KLS0tIDhIZnFSUzFNUFFqRUlHL1FHT3lx
-            Y1orT2ZHdzY1cHIwVm4rWnhITXBuWG8KmwN+Nz+FOTZtNeEdWT+g7pIy8du1vJyG
-            gs2KvzeTcQ/k+bEET0sRFxpV8W/hsyvDFZP9sCHAgQmswnPWlkbe0w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwNUVOLzhLZlVTQWMxMkJD
+            SkpxampiSXpqRCsrUEZuMHRCdG1oa3duZHg4Cjg3WWpYSXR4VVNESm53bU1sVG1K
+            dnlVdmY5L2pWQjBsZVF5OGNaSTRBd0kKLS0tIDU1SWt5TXlTNnFYS044NklMbUVo
+            MDV3V3NWNU1MVFg3cDM0enhYUnFHRFkKkdf7yxV+YeJHxY50L0TXRWA3BIMgkZF5
+            waLqYYF7TX4y0O0vwkV0fDUpZ67nCXb9+lu6GXMa7hnjlpzdNYFyPw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-28T21:42:08Z"
-    mac: ENC[AES256_GCM,data:q1EhrLakmg2cdFXtTiR3cszHqLs4/PuwehXhFWfIks1dc/7QOsPdkiKAeR83Bj/FiRWXilPmKeBztcSCenOh4BDWuRDV6bKFKwNN/pDYMKo0ts3bWGLNOYSywnRjOhh3m/yP5JFAD/8Jwo2itZoUhdum/mYJvf6hLQIXmAtqQc8=,iv:JhkyWk+cgV+MTEII0ikyOzVH8r8E3Ps7n+Ws10R5fQE=,tag:lMPM3XiSY9aNXTjmtFeAaA==,type:str]
+    lastmodified: "2025-04-29T08:32:24Z"
+    mac: ENC[AES256_GCM,data:Si6Ybx2dtWxPTEnCTgNhBkFJ5C3RLscPB8qrFu15SduanxW0WzzEIvIBy0aDC/8CvH1/E9/4Mid9vDdsajhOD1ki75+KAu4ucNXToeXQkCfpXXmCKij/DAPv/bydUnhdIAx5RdM8r49qOtDnV7na+miK9+9TElHIhKXIoWLK69U=,iv:NPaGNilXFDc9ZEh4Wc6zHlVtrMr0pG/KpJPB5pbo3r4=,tag:4VYu3wBbttwF6VH+W8Oh/A==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.9.0


### PR DESCRIPTION
This commit addresses two key improvements for the Kopia application:

- **Storage Configuration:**  Switched Kopia storage from B2 to S3, since the library used by kopia to access b2 is 4 years old now.
- **Group ID Fix:** Corrected the `supplementalGroups` value in the HelmRelease to `1000` to align with the user/group setup.