### PR TITLE
feat(flux): switch bjw-s helm repo to oci format

### DIFF
--- a/kubernetes/flux/repositories/helm/bjw-s.yaml
+++ b/kubernetes/flux/repositories/helm/bjw-s.yaml
@@ -1,9 +1,11 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrepository-source-v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bjw-s
   namespace: flux-system
 spec:
-  interval: 1h
-  url: https://bjw-s.github.io/helm-charts/
+  type: "oci"
+  interval: 30m
+  url: oci://ghcr.io/bjw-s/helm


### PR DESCRIPTION
This commit switches the bjw-s helm repository source from a standard URL to an OCI (Open Container Initiative) format.

The update also reduces the check interval to 30 minutes.