### PR TITLE
feat: migrate echo-server chart source to oci repository

### DIFF
--- a/kubernetes/apps/default/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo-server/app/helmrelease.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -5,16 +6,11 @@ metadata:
   name: &app echo-server
   namespace: default
 spec:
-  interval: 15m
-  chart:
-    spec:
-      interval: 15m
-      chart: app-template
-      version: 3.7.3
-      sourceRef:
-        kind: HelmRepository
-        name: bjw-s
-        namespace: flux-system
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
   install:
     remediation:
       retries: 3

--- a/kubernetes/flux/repositories/oci/bjw-s-oci.yaml
+++ b/kubernetes/flux/repositories/oci/bjw-s-oci.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: app-template
+  namespace: flux-system
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.7.3
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Migrates the `echo-server` application's chart source from a Helm repository to an OCI repository.

- Introduces a new `OCIRepository` resource named `app-template` in the `flux-system` namespace.
- Configures the `HelmRelease` to reference the chart via `chartRef` pointing to the OCI repository.
- Updates the interval to 1h for HelmRelease.
- Adds layerSelector to only copy helm charts.