### PR TITLE
feat(vpn-gateway): add node affinity to webhook deployment

### DIFF
--- a/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
@@ -22,6 +22,25 @@ spec:
   upgrade:
     remediation:
       retries: 5
+  postRenderers:
+    # temp solution for https://github.com/angelnu/gateway-admision-controller/issues/299
+    - kustomize:
+        patches:
+          - target:
+              version: v1
+              kind: Deployment
+              name: vpn-gateway-pod-gateway-webhook
+            patch: |
+              - op: add
+                path: /spec/template/spec/affinity
+                value:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: "kubernetes.io/arch"
+                              operator: In
+                              values: ["amd64"]
   values:
     image:
       repository: ghcr.io/angelnu/pod-gateway


### PR DESCRIPTION
This commit adds a node affinity to the `vpn-gateway-pod-gateway-webhook` deployment.

This ensures the webhook is scheduled on `amd64` nodes, addressing a known issue with the admission controller.
This is a temporary solution until the underlying issue is resolved.

ref: https://github.com/angelnu/gateway-admision-controller/issues/299