### PR TITLE
feat(renovate): configure renovate to properly version kopia docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,6 +49,15 @@
       matchDatasources: [
         'docker',
       ],
+      versioning: 'regex:^v(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))$',
+      matchPackageNames: [
+        'docker.io/kopia/kopia',
+      ],
+    },
+    {
+      matchDatasources: [
+        'docker',
+      ],
       versioning: 'regex:^(?<major>\\d{6})$',
       matchPackageNames: [
         'docker.io/photoprism/photoprism',


### PR DESCRIPTION
This commit updates the renovate configuration to correctly version `docker.io/kopia/kopia` images. A regex pattern is added to extract major, minor, and patch versions, ignoring the unstable yyyymmdd format for dev releases.