### PR TITLE
feat(renovate): sync intel-gpu-plugin group with kubernetes device plugins

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -14,7 +14,7 @@
     {
       "description": "intel-gpu-plugin images and tags",
       "groupName": "intel-gpu-plugin",
-      "matchPackagePatterns": ["intel-gpu-plugin"],
+      "matchPackagePatterns": ["intel-gpu-plugin", "intel/intel-device-plugins-for-kubernetes"],
       "matchDatasources": ["docker", "github-releases"],
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"


### PR DESCRIPTION
This commit updates the `intel-gpu-plugin` renovate group to include `intel/intel-device-plugins-for-kubernetes` package. This ensures updates for both the core plugin and the Kubernetes device plugins are managed together.