### PR TITLE
feat(jellyfin): add intro mount

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -127,6 +127,12 @@ spec:
         path: "${NFS_MEDIA}/tvshows"
         globalMounts:
           - path: "/media/tvshows"
+      intros:
+        type: nfs
+        server: "${NFS_SERVER}"
+        path: "${NFS_MEDIA}/intros"
+        globalMounts:
+          - path: "/media/intros"
       transcode:
         enabled: true
         type: emptyDir


### PR DESCRIPTION
This commit adds a new NFS mount for intro videos to the Jellyfin application.

- Added `intros` volume definition in `helmrelease.yaml`.
- Configured NFS server and path for intro storage.
- Mapped the mount to `/media/intros` within the container.