### PR TITLE
feat: increase storage for Jellyfin and Sonarr

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -111,7 +111,7 @@ spec:
         enabled: true
         type: persistentVolumeClaim
         storageClass: longhorn
-        size: 10Gi
+        size: 20Gi
         retain: true
         globalMounts:
           - path: /config

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -108,7 +108,7 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         storageClass: longhorn
-        size: 3Gi
+        size: 10Gi
         labels:
           recurring-job-group.longhorn.io/backup: enabled
       downloads:


### PR DESCRIPTION
Increased Jellyfin config storage from 10Gi to 20Gi and Sonarr storage from 3Gi to 10Gi.