### PR TITLE
feat(postgres): Update image to vchord variant

### DIFF
--- a/kubernetes/apps/databases/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/postgres/app/helmrelease.yaml
@@ -39,8 +39,8 @@ spec:
       usePasswordFiles: false
     image:
       registry: ghcr.io
-      repository: thiagoalmeidasa/bitnami-postgres-pgvecto-rs
-      tag: 16.4.0-debian-12-r16@sha256:8050eecbcdac616d8ff6c9d0b9ecaff117fae219db34d1b7a8e53f92446599b1
+      repository: thiagoalmeidasa/bitnami-postgres-pgvecto-rs-vchord
+      tag: 16.4.0-debian-12-r16@sha256:12852f64cd26db15a5549173615c9ef8d1464ff0ad75692180fdfeaa1c7cedfe
     primary:
       persistence:
         enabled: true


### PR DESCRIPTION
This commit updates the postgres image repository to `thiagoalmeidasa/bitnami-postgres-pgvecto-rs-vchord` and adjusts the image tag's sha256 hash. This change introduces the vchord variant as preparation work for immich v1.333.0 upgrade.

https://immich.app/docs/administration/postgres-standalone/#migrating-to-vectorchord

The first step is to use a image that contains both extesions and in the future use only vchord.