### PR TITLE
feat(distcc): added distcc for manjaro

### DIFF
--- a/kubernetes/apps/default/distcc/app/daemonset.yaml
+++ b/kubernetes/apps/default/distcc/app/daemonset.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: distcc
+  namespace: default
+  labels:
+    app: distcc
+spec:
+  selector:
+    matchLabels:
+      name: distcc
+  template:
+    metadata:
+      labels:
+        name: distcc
+    spec:
+      containers:
+        - name: distcc
+          image: ghcr.io/thiagoalmeidasa/manjarolinux-distcc:20250504
+          ports:
+            - containerPort: 3632
+              hostPort: 3632
+              protocol: TCP
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64

--- a/kubernetes/apps/default/distcc/app/kustomization.yaml
+++ b/kubernetes/apps/default/distcc/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./daemonset.yaml

--- a/kubernetes/apps/default/distcc/ks.yaml
+++ b/kubernetes/apps/default/distcc/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: distcc
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/default/distcc/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./distcc/ks.yaml
   - ./echo-server/ks.yaml
   - ./hajimari/ks.yaml
   - ./immich/ks.yaml


### PR DESCRIPTION
This commit introduces distcc, a distributed compiler, to the Kubernetes cluster.

It includes:
- DaemonSet definition for distcc pods.
- Kustomization for deploying distcc.
- Flux Kustomization to manage distcc deployment.

This allows leveraging distributed compilation for faster build times.