### PR TITLE
feat(longhorn): upgrade longhorn recurring job api version to v1

### DIFF
--- a/kubernetes/apps/storage/longhorn/recurring-jobs/backup-weekly.yaml
+++ b/kubernetes/apps/storage/longhorn/recurring-jobs/backup-weekly.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1
 kind: RecurringJob
 metadata:
   name: backup-weekly

--- a/kubernetes/apps/storage/longhorn/recurring-jobs/snapshot-daily.yaml
+++ b/kubernetes/apps/storage/longhorn/recurring-jobs/snapshot-daily.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1
 kind: RecurringJob
 metadata:
   name: snapshot

--- a/kubernetes/apps/storage/longhorn/recurring-jobs/volume-trim-daily.yaml
+++ b/kubernetes/apps/storage/longhorn/recurring-jobs/volume-trim-daily.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: longhorn.io/v1beta2
+apiVersion: longhorn.io/v1
 kind: RecurringJob
 metadata:
   name: recurring-fs-trim-per-day


### PR DESCRIPTION
This commit upgrades the API version for Longhorn's recurring jobs (backup, snapshot, and volume trim) from `v1beta1` or `v1beta2` to `v1`.