### PR TITLE
feat(hass): increase config pvc

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -144,7 +144,7 @@ spec:
         storageClass: longhorn
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
-        size: 3Gi
+        size: 6Gi
         globalMounts:
           - path: /config
       ssh:


### PR DESCRIPTION
Increases the persistent volume claim size for the Home Assistant configuration from 3Gi to 6Gi.