### PR TITLE
feat(nginx-ingress): increase proxy buffer sizes

### DIFF
--- a/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
@@ -58,7 +58,8 @@ spec:
           "request_length": $request_length, "duration": $request_time, "method": "$request_method", "http_referrer": "$http_referer",
           "http_user_agent": "$http_user_agent"}
         proxy-body-size: 0
-        proxy-buffer-size: 16k
+        proxy-buffer-size: "32k"
+        proxy-busy-buffers-size: "32k"
         ssl-protocols: TLSv1.3 TLSv1.2
       metrics:
         enabled: true


### PR DESCRIPTION
Increases `proxy-buffer-size` and adds `proxy-busy-buffers-size` to 32k. This should improve handling of larger request/response bodies and potentially reduce 502 errors under load.

https://github.com/kubernetes/ingress-nginx/issues/13598