### PR TITLE
feat: Consolidate Healthcheck Tokens & Add Backups for Immich & Photoprism

### DIFF
--- a/ansible/inventory/host_vars/cn3.lan.sops.yml
+++ b/ansible/inventory/host_vars/cn3.lan.sops.yml
@@ -1,12 +1,11 @@
-kind: ENC[AES256_GCM,data:WEaqBQGT,iv:rj8zYnO2jakELgAIZ82BxrbxP9e9w1aA3+CJNvzG/sE=,tag:CEsnAXT4yXv/YfB/w/xhDw==,type:str]
-ansible_user: ENC[AES256_GCM,data:IiI/B7o=,iv:YDXST70uCb2xh1BylbshxniYxTnloSPzBEXYKSgHQvg=,tag:PLTGmwt7RHzCiIVsNCtLtQ==,type:str]
-longhorn_host: ENC[AES256_GCM,data:MOCtrKSzLA==,iv:Pe+WnJdq1LEvm8+qhC/l617/IANwa++ccd8zclpaCtY=,tag:A+aRw9Cews8U03lXR00X7w==,type:str]
-longhorn_user: ENC[AES256_GCM,data:rhulmqU=,iv:tXF35so+slKS6jKosodJFsxOdA/YNUQpKp4hts3W9ps=,tag:FkV83Mzk4LNkgNSiZEwh4w==,type:str]
-healthchecks_rsync_token: ENC[AES256_GCM,data:kMepS6hE6T3Eb28IhIcuysieo+qNevunsMQr1A8kzdzTDnnl,iv:y/cbFtcTLnwZpCsOnulrrhz4FAokC5ipfUB/M3tpH6I=,tag:MWRNg485QJBLsGJsa3iOog==,type:str]
+kind: ENC[AES256_GCM,data:LwSCil3a,iv:ouGxSdZdH56D7ZfeMHEHyZ4RwqRPLozT+d7rmMsjfnk=,tag:deRq/3HTo2sGjLQNpB2quw==,type:str]
+ansible_user: ENC[AES256_GCM,data:s56SOCg=,iv:6TsJqYpYRv/WsVmMpPy0d8FZ60Ovg2gzUGaByxECLDQ=,tag:usQHSGpSordjRkU4zPVntA==,type:str]
+longhorn_host: ENC[AES256_GCM,data:/ZJeNJ2Gmg==,iv:oHISmT9rVGwCDJT0tymDeKEwk4BCkHu/fXGuw2q23IA=,tag:C78e3KUjCskj6p9xcH/tmA==,type:str]
+longhorn_user: ENC[AES256_GCM,data:5PI/C1w=,iv:8xXEmDjRYlK1QtMr1eCxhXan+UE3VKUqbYfaKJuFh0o=,tag:JuWyM3XVds8WZdEimGiBWw==,type:str]
 healthchecks_tokens:
-    longhorn: ENC[AES256_GCM,data:8bkWCp0S+vKamvlhDkZtPFCi9qI7mF+uuFKYfoHvEykt0L+6,iv:BnAP3lC473Nk+WoYxwqMxzHNN4X5E3mVt9bhGE8z9Oc=,tag:6VE0XtxSwO30YJZgzZi9nA==,type:str]
-    immich: ENC[AES256_GCM,data:i8pnLNLRXeaQL3jN3Zw2HnGTkVZB7wTBtgPp21fAxCcfKmxY,iv:MWTSPcKtkW7/hwVStig97fyKGE3xjuCsLsxDX44U854=,tag:6RXkjB6CrNEdgSxLXenGCg==,type:str]
-    photoprism: ENC[AES256_GCM,data:Z96rtkae+wnVh566wm+zAwQb94mmWALNALGsZ4B0tv5EdsCY,iv:y3DyMfq5JT4qIY4AVKyQWlWZ572W5fy9v6Ak4CjPsYE=,tag:QD0tplLwjm1pq6AE6Zh7EA==,type:str]
+    longhorn: ENC[AES256_GCM,data:7RgKjBp2PYS9ezMq5EiGweAV66BWSra/fSak34iGZn8LyZge,iv:MNmLP+OvpWKARTrNlLqF2+fckRILdfQB7kom51VZZHY=,tag:T0iEWfbEeYPh/w92T3cdaw==,type:str]
+    immich: ENC[AES256_GCM,data:2SeYfyggoU80HbIE9JBZumK8rWVGU0i7eaAlVHtb+ZOyiXHI,iv:sNYBV3777/AXoaidr9/s2/6quQhM3VKlUYn02MjvrAU=,tag:UUsZtMzf/oGwrMIPbYQOIw==,type:str]
+    photoprism: ENC[AES256_GCM,data:Xdp2K0k/SVJeO/WrMaRvP+1Tj9dlAELSZCdnA7ubY9Qs+Tq5,iv:TO2gwCFd/GRwnlwR2C3hN643R4RQmDjliVgPRJ6rV3I=,tag:E985OEDS8q8GA/MUfhgDnQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -16,14 +15,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1T0pkeDhIVE9rZ2c1T3F3
-            dEJmekZPS0U4ZHBGL25XUWNvb3AvYTBka0dvCkVEN2VJSWpaZ1VFa2UzMGVGN1kx
-            a3VDZW1OOTFBaTk2THJkN1FvcWRTcU0KLS0tIElmYXlEZllHT2cwb29oYU4vdUZl
-            RHhDMTd1b1VHRGZxUUJ4U3cveFFPVncKBKIp1fmoDYWeL7UoWOqdWfPcXQ0N25PL
-            3gpLLmBnDZCKIm3bok/NyRfwseszpxngTViLan+6fzxhGHfkGqmZHQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1dTd4Q09oMlpoeTVyL3VV
+            SGlieGR2Vk8vcnkzNnlycUFxTjJkL1VpR0ZBCk9XS01jVDMyT3lyWDZwK0VnOUhu
+            RWdEVHNpcnBFYlFkYjk5ZXNCdDdPQ3MKLS0tIG0wYWVBVEpORzZGd0xUQUlEVFJs
+            T1lNd3VuUTdWNFFVUkg5Vkt2U1BFS0kKTKOC3qVTsf0G2e4AvHUtv0xQ//4Zzb1Y
+            6qlzZ4KXvVT0SwJZYEDwfIBNPcQnD5XtbNeAtvAXvKxr5oHLU2SwCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-15T22:28:57Z"
-    mac: ENC[AES256_GCM,data:JnIVVkIqBfIUwpQ6E5g4IX4a/A9IgriT8nyz0aqHVAhLptYTvAjuiFwtvxn1KZg6af0XovsPJOldTqyjW76iSkTJdks+kQjQ7Tx/gpAgwlK1Q+BjJU22mZ5TmDW/Clc7N1R9OkAIGhHhQOjlvQ2nulEb1Knqb+zYaxt0bjZRMdI=,iv:PllahkydHoK36mklDj3dLYiz4YPUM82kTMxbzNu+Fwo=,tag:wU6UbC/9kfB91vdna7MeWA==,type:str]
+    lastmodified: "2025-07-15T22:56:41Z"
+    mac: ENC[AES256_GCM,data:UOU9+UgcWKbYX/mWV/j6mYZ0eC7SKDegBj5W2Nuz3HwnsPVZeAUX9gyhPB+SH4mHY5WxrTLQCLDsxcU3DWJkFHYXHa0J/kCDYrm0OTzHkwDZv6GSVpiSNkl11wUPNzAJOqz4va6YJivKaL7x8P2zuqGrSW5EPUbhNFvl5Mo6B1E=,iv:wTQwQvbJ5HfyOaj7s2EQXSDGJsqWG0PEVTgwyvhznHc=,tag:R9WmreDVO0t0U2k/tNiKUw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.4

--- a/ansible/inventory/host_vars/cn3.lan.sops.yml
+++ b/ansible/inventory/host_vars/cn3.lan.sops.yml
@@ -1,8 +1,12 @@
-kind: ENC[AES256_GCM,data:WPxmR/h8,iv:7MCF85fCxX6pP/yoLh9JzWNeSmkmObQusrgNTSZKT90=,tag:8DV3n9hIBgEzW0RwbqwLlw==,type:str]
-ansible_user: ENC[AES256_GCM,data:oDS7znQ=,iv:uhQ9nlJvS3sBcKVbSj9lQMNbDxHy37v+Va78ppQkUbg=,tag:sPxfvIZzfahBrrUsUfuZzg==,type:str]
-longhorn_host: ENC[AES256_GCM,data:uRrhmoAqtQ==,iv:upaJs5PXN5YRsJG5mRU5uJ5y+jfREQNZQZFeAwsCZTU=,tag:wg00PBZNI+7pvGqTwVUcWQ==,type:str]
-longhorn_user: ENC[AES256_GCM,data:NTsbPj0=,iv:yZbt4LD+JIy3LUq8WE/ns9X9vIWlNlMGf6Hyk5oA0AQ=,tag:JszzyfBprZLO5nJ99X1PXQ==,type:str]
-healthchecks_rsync_token: ENC[AES256_GCM,data:8P1LmckDkL57Q1zbzfUPlCTb2l1PD969pCzrhYcxWlr0BoOy,iv:x8RAARDHWdtk5tIlUuVX0IlQr4zxNZLlap9SpfUSDSo=,tag:Bgv8LSzKvunlJsjzeFD0xg==,type:str]
+kind: ENC[AES256_GCM,data:WEaqBQGT,iv:rj8zYnO2jakELgAIZ82BxrbxP9e9w1aA3+CJNvzG/sE=,tag:CEsnAXT4yXv/YfB/w/xhDw==,type:str]
+ansible_user: ENC[AES256_GCM,data:IiI/B7o=,iv:YDXST70uCb2xh1BylbshxniYxTnloSPzBEXYKSgHQvg=,tag:PLTGmwt7RHzCiIVsNCtLtQ==,type:str]
+longhorn_host: ENC[AES256_GCM,data:MOCtrKSzLA==,iv:Pe+WnJdq1LEvm8+qhC/l617/IANwa++ccd8zclpaCtY=,tag:A+aRw9Cews8U03lXR00X7w==,type:str]
+longhorn_user: ENC[AES256_GCM,data:rhulmqU=,iv:tXF35so+slKS6jKosodJFsxOdA/YNUQpKp4hts3W9ps=,tag:FkV83Mzk4LNkgNSiZEwh4w==,type:str]
+healthchecks_rsync_token: ENC[AES256_GCM,data:kMepS6hE6T3Eb28IhIcuysieo+qNevunsMQr1A8kzdzTDnnl,iv:y/cbFtcTLnwZpCsOnulrrhz4FAokC5ipfUB/M3tpH6I=,tag:MWRNg485QJBLsGJsa3iOog==,type:str]
+healthchecks_tokens:
+    longhorn: ENC[AES256_GCM,data:8bkWCp0S+vKamvlhDkZtPFCi9qI7mF+uuFKYfoHvEykt0L+6,iv:BnAP3lC473Nk+WoYxwqMxzHNN4X5E3mVt9bhGE8z9Oc=,tag:6VE0XtxSwO30YJZgzZi9nA==,type:str]
+    immich: ENC[AES256_GCM,data:i8pnLNLRXeaQL3jN3Zw2HnGTkVZB7wTBtgPp21fAxCcfKmxY,iv:MWTSPcKtkW7/hwVStig97fyKGE3xjuCsLsxDX44U854=,tag:6RXkjB6CrNEdgSxLXenGCg==,type:str]
+    photoprism: ENC[AES256_GCM,data:Z96rtkae+wnVh566wm+zAwQb94mmWALNALGsZ4B0tv5EdsCY,iv:y3DyMfq5JT4qIY4AVKyQWlWZ572W5fy9v6Ak4CjPsYE=,tag:QD0tplLwjm1pq6AE6Zh7EA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -12,14 +16,14 @@ sops:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Qm0ydGMyY1M0b1NRbzUv
-            Q3QwTGFMSk42QU5wdkZ6L21YaTRTZmlsZkg0CkVmUGJRbHNVOHZJejFleWhBRnpn
-            T3JwdGdYQWVUcXg5OSs4T2JENExJaG8KLS0tIGpmVm1DeWpVZ0lOYVVhMVR4L2VR
-            MUEveEZKT29lMzNwY294eWhsemN3ck0KSBYTRdzz+HcUviZY9ZcwJchCC0hmHtiP
-            lMUI12aGT1gxwqbpukkhLJIXCiNVM7Va8wGQ772lh9+6UGM+Bc7NNw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1T0pkeDhIVE9rZ2c1T3F3
+            dEJmekZPS0U4ZHBGL25XUWNvb3AvYTBka0dvCkVEN2VJSWpaZ1VFa2UzMGVGN1kx
+            a3VDZW1OOTFBaTk2THJkN1FvcWRTcU0KLS0tIElmYXlEZllHT2cwb29oYU4vdUZl
+            RHhDMTd1b1VHRGZxUUJ4U3cveFFPVncKBKIp1fmoDYWeL7UoWOqdWfPcXQ0N25PL
+            3gpLLmBnDZCKIm3bok/NyRfwseszpxngTViLan+6fzxhGHfkGqmZHQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-20T08:28:24Z"
-    mac: ENC[AES256_GCM,data:NgX6tzVE1unR3IFDmG//VDsTKk5WBTleemfLJNePkKz+sQ9aHy6LdFvOfqnnZq4QszYqaGiosw4Tw5zBLZJjQVXRKjjpE9G2JX7VmyCUIIjmlOdx7YNtWnPGXFchBISzMg9vxyzTjehevia3ZOHFtDTXdkGmVC+RzGbIHb91a8U=,iv:l9sqPi/0x/YShezR5Wt5xdr0bo1NZkTY3+iyCmIRDvs=,tag:1GRR8x3VJGxdZMsC2YGtLA==,type:str]
+    lastmodified: "2025-07-15T22:28:57Z"
+    mac: ENC[AES256_GCM,data:JnIVVkIqBfIUwpQ6E5g4IX4a/A9IgriT8nyz0aqHVAhLptYTvAjuiFwtvxn1KZg6af0XovsPJOldTqyjW76iSkTJdks+kQjQ7Tx/gpAgwlK1Q+BjJU22mZ5TmDW/Clc7N1R9OkAIGhHhQOjlvQ2nulEb1Knqb+zYaxt0bjZRMdI=,iv:PllahkydHoK36mklDj3dLYiz4YPUM82kTMxbzNu+Fwo=,tag:wU6UbC/9kfB91vdna7MeWA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.4

--- a/ansible/playbooks/second-layer-backup-setup.yaml
+++ b/ansible/playbooks/second-layer-backup-setup.yaml
@@ -49,11 +49,39 @@
             cache_valid_time: "{{ 3600 * 7 }}"
           with_items:
             - rsync
-        - name: Setup cron for rsync
+
+        - name: Setup Longhorn Backup Rsync Cron Job
           ansible.builtin.cron:
             name: "Sync Longhorn backup folder"
-            job: "rsync -aAXHv --delete {{ longhorn_user }}@{{ longhorn_host}}:/volume1/backups/k8s/longhorn/ /mnt/data/backups/longhorn/ && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/{{ healthchecks_rsync_token }}"
+            job: >
+              rsync -aAXHv --delete {{ longhorn_user }}@{{ longhorn_host }}:/volume1/backups/k8s/longhorn/
+              /mnt/data/backups/longhorn/ &&
+              curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/{{ healthchecks_tokens.longhorn }}
             user: cubie
             minute: 20
             hour: 6
+            weekday: 1,4
+
+        - name: Setup Immich Backup Rsync Cron Job
+          ansible.builtin.cron:
+            name: "Sync Immich backup folder"
+            job: >
+              rsync -aAXHv --delete {{ longhorn_user }}@{{ longhorn_host }}:/volume1/backups/k8s/immich/
+              /mnt/data/backups/immich/ &&
+              curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/{{ healthchecks_tokens.immich }}
+            user: cubie
+            minute: 20
+            hour: 9
+            weekday: 1,4
+
+        - name: Setup Photoprism Backup Rsync Cron Job
+          ansible.builtin.cron:
+            name: "Sync Photoprism backup folder"
+            job: >
+              rsync -aAXHv --delete {{ longhorn_user }}@{{ longhorn_host }}:/volume1/backups/k8s/photoprism/
+              /mnt/data/backups/photoprism/ &&
+              curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/{{ healthchecks_tokens.photoprism }}
+            user: cubie
+            minute: 20
+            hour: 12
             weekday: 1,4


### PR DESCRIPTION
This pull request introduces two key improvements: consolidation of healthcheck tokens and the addition of backup jobs for Immich and Photoprism.

Changes included:

* Healthcheck Token Consolidation: The healthchecks_rsync_token variable has been consolidated into the healthchecks_tokens map under the longhorn key. This simplifies configuration and provides a more consistent approach to managing healthcheck tokens. The old token variable has been removed.
* New Backup Jobs: Backup jobs have been added for Immich and Photoprism, mirroring the existing Longhorn backup setup. This includes new cron jobs for rsyncing backup folders from cn3.lan to the backup server, and updates to the inventory file to include tokens for these new services.