### PR TITLE
feat(photoprism): adjust resource limits and requests

### DIFF
--- a/kubernetes/apps/default/photoprism/app/helmrelease.yaml
+++ b/kubernetes/apps/default/photoprism/app/helmrelease.yaml
@@ -63,12 +63,12 @@ spec:
                   name: photoprism-secret
             resources:
               limits:
-                cpu: 2
-                memory: 2Gi
+                cpu: 300m
+                memory: 2.5Gi
                 gpu.intel.com/i915: 1
               requests:
-                cpu: 1
-                memory: 400Mi
+                cpu: 30m
+                memory: 100Mi
                 gpu.intel.com/i915: 1
 
             probes:


### PR DESCRIPTION
This commit adjusts the resource limits for the Photoprism application.

- CPU limit updated from 2 to 300m.
- Memory limit updated from 2Gi to 2.5Gi.
- CPU request updated from 1 to 30m.
- Memory request updated from 400Mi to 100Mi.