### PR TITLE
fix(app-template): update bjw-s helm repository URL

### DIFF
--- a/kubernetes/flux/repositories/helm/bjw-s.yaml
+++ b/kubernetes/flux/repositories/helm/bjw-s.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   type: "oci"
   interval: 30m
-  url: oci://ghcr.io/bjw-s/helm
+  url: oci://ghcr.io/bjw-s-labs/helm


### PR DESCRIPTION
The URL for the bjw-s helm repository has been updated from `oci://ghcr.io/bjw-s/helm` to `oci://ghcr.io/bjw-s-labs/helm`.