### PR TITLE
fix(renovate): update matchPackagePatterns for intel-gpu-plugin

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -14,7 +14,7 @@
     {
       "description": "intel-gpu-plugin images and tags",
       "groupName": "intel-gpu-plugin",
-      "matchPackagePatterns": ["intel-gpu-plugin", "intel/intel-device-plugins-for-kubernetes"],
+      "matchPackagePatterns": ["intel/intel-gpu-plugin", "intel/intel-device-plugins-for-kubernetes"],
       "matchDatasources": ["docker", "github-releases"],
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"


### PR DESCRIPTION
Updated the matchPackagePatterns in renovate/groups.json5 to correctly specify the package pattern for intel-gpu-plugin.