### PR TITLE
fix(renovate): update matchDatasources for intel-gpu-plugin

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -15,7 +15,7 @@
       "description": "intel-gpu-plugin images and tags",
       "groupName": "intel-gpu-plugin",
       "matchPackagePatterns": ["intel/intel-gpu-plugin", "intel/intel-device-plugins-for-kubernetes"],
-      "matchDatasources": ["docker", "github-releases"],
+      "matchDatasources": ["docker", "github-tags"],
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"
       },


### PR DESCRIPTION
Updated the matchDatasources field from 'github-releases' to 'github-tags' in the intel-gpu-plugin group configuration.