### PR TITLE
feat(jellyfin): add Prometheus alerts for Jellyfin

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/alerts.yaml
+++ b/kubernetes/apps/media/jellyfin/app/alerts.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: jellyfin-rules
+  namespace: media
+spec:
+  groups:
+    - name: jellyfin.rules
+      rules:
+        - alert: jellyfinComponentAbsent
+          annotations:
+            summary: Jellyfin Component has disappeared from Prometheus target discovery.
+          expr: absent(up{job="jellyfin"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+        - alert: jellyfinTooManyFailedLogins
+          expr: increase(microsoft_aspnetcore_hosting_http_server_request_duration_count{http_response_status_code="401", http_route="Users/AuthenticateByName"}[1m]) > 3
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Jellyfin has a high number of failed login attempts"
+            description: "More than 3 failed login attempts to /Users/AuthenticateByName in the last minute."

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - helmrelease.yaml
-  - pdb.yaml
+  - ./helmrelease.yaml
+  - ./pdb.yaml
+  - ./alerts.yaml


### PR DESCRIPTION
- An alert to notify when a Jellyfin component is absent from Prometheus target discovery.
- An alert to notify when there are too many failed login attempts to Jellyfin.