### PR TITLE
feat(ansible): bump prometheus-operator CRDs to v0.90.1

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -20,6 +20,19 @@
         "commitMessageTopic": "{{{groupName}}} group"
       },
       "separateMinorPatch": true
+    },
+    {
+      "description": "Prometheus Operator chart and CRDs",
+      "groupName": "prometheus-operator",
+      "matchPackageNames": [
+        "kube-prometheus-stack",
+        "prometheus-operator/prometheus-operator"
+      ],
+      "matchDatasources": ["helm", "github-releases"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} group"
+      },
+      "separateMinorPatch": true
     }
   ]
 }

--- a/ansible/inventory/group_vars/kubernetes/k3s.yml
+++ b/ansible/inventory/group_vars/kubernetes/k3s.yml
@@ -38,31 +38,37 @@ k3s_registries:
     quay.io:
     registry.k8s.io:
 
+# (string) Prometheus Operator CRD version. Should match the appVersion of
+# the kube-prometheus-stack chart deployed via Flux. Cluster must be newer or
+# equal to this version.
+# renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
+prometheus_operator_version: "v0.90.1"
+
 # (list) A list of URLs to deploy on the primary control plane. Read notes below.
 k3s_server_manifests_urls:
   # Kube-vip
   - url: https://kube-vip.io/manifests/rbac.yaml
     filename: custom-kube-vip-rbac.yaml
   # Prometheus Operator
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml"
     filename: custom-prometheus-alertmanagerconfigs.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml"
     filename: custom-prometheus-alertmanagers.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml"
     filename: custom-prometheus-podmonitors.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml"
     filename: custom-prometheus-probes.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
     filename: custom-prometheus-prometheuses.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml"
     filename: custom-prometheus-prometheusrules.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
     filename: custom-prometheus-servicemonitors.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
     filename: custom-prometheus-thanosrulers.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml"
     filename: custom-prometheus-scrapeconfigs.yaml
-  - url: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.81.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+  - url: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{{ prometheus_operator_version }}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml"
     filename: custom-prometheus-prometheusagents.yaml
 
 # (list) A flat list of templates to deploy on the primary control plane


### PR DESCRIPTION
## Summary
- Bump prometheus-operator CRDs from v0.81.0 to v0.90.1 to match `kube-prometheus-stack` 83.6.0 `appVersion` running on the cluster.
- Templatize the CRD version into a single `prometheus_operator_version` var with a renovate annotation so future bumps flow through automatically.
- Add a renovate group rule so the chart bump and CRD bump land in the same PR going forward.