### PR TITLE
feat(default): add homepage dashboard alongside hajimari

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -1,0 +1,189 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app homepage
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+
+  values:
+    controllers:
+      homepage:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        serviceAccount:
+          name: homepage
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gethomepage/homepage
+              tag: v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401
+            env:
+              LOG_LEVEL: info
+              HOMEPAGE_ALLOWED_HOSTS: "homepage.${SECRET_DOMAIN}"
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthcheck
+                    port: &port 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: [ALL]
+
+    defaultPodOptions:
+      labels:
+        lan-only: "true"
+
+    serviceAccount:
+      homepage: {}
+
+    service:
+      app:
+        controller: homepage
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/config/logs
+      config:
+        type: configMap
+        name: homepage-config
+        globalMounts:
+          - path: /app/config/settings.yaml
+            subPath: settings.yaml
+            readOnly: true
+          - path: /app/config/services.yaml
+            subPath: services.yaml
+            readOnly: true
+          - path: /app/config/bookmarks.yaml
+            subPath: bookmarks.yaml
+            readOnly: true
+          - path: /app/config/widgets.yaml
+            subPath: widgets.yaml
+            readOnly: true
+          - path: /app/config/kubernetes.yaml
+            subPath: kubernetes.yaml
+            readOnly: true
+          - path: /app/config/docker.yaml
+            subPath: docker.yaml
+            readOnly: true
+          - path: /app/config/custom.css
+            subPath: custom.css
+            readOnly: true
+          - path: /app/config/custom.js
+            subPath: custom.js
+            readOnly: true
+
+    configMaps:
+      config:
+        enabled: true
+        data:
+          settings.yaml: |
+            title: Rasp K3s
+            headerStyle: clean
+            theme: dark
+            color: slate
+            layout:
+              Media:
+                style: row
+                columns: 4
+              Monitoring:
+                style: row
+                columns: 4
+              k8s-at-home:
+                header: true
+                style: column
+              Tech:
+                header: true
+                style: column
+            providers: {}
+          services.yaml: |
+            - Media:
+                - Transmission:
+                    href: http://storage.lan:9092/
+                    icon: mdi-folder-download
+            - Monitoring:
+                - PagerDuty:
+                    href: https://smoothship.eu.pagerduty.com/
+                    icon: mdi-alert
+          bookmarks.yaml: |
+            - k8s-at-home:
+                - thiagoalmeidasa/homelab:
+                    - abbr: HL
+                      href: https://github.com/thiagoalmeidasa/homelab/
+                - Template repo:
+                    - abbr: TR
+                      href: https://github.com/onedr0p/flux-cluster-template
+                - Helm charts:
+                    - abbr: HC
+                      href: https://github.com/bjw-s/helm-charts/tree/main/charts/library/common
+                - onedr0p/home-cluster:
+                    - abbr: O7
+                      href: https://github.com/onedr0p/home-cluster
+                - cbirkenbeul/homelab:
+                    - abbr: CB
+                      href: https://github.com/cbirkenbeul/homelab
+                - bjw-s/home-ops:
+                    - abbr: BJ
+                      href: https://github.com/bjw-s/home-ops
+            - Tech:
+                - Hacker News:
+                    - abbr: HN
+                      href: https://news.ycombinator.com/
+                - The Verge:
+                    - abbr: TV
+                      href: https://theverge.com/
+                - MIT Technology Review:
+                    - abbr: MT
+                      href: https://www.technologyreview.com/
+          widgets.yaml: |
+            - kubernetes:
+                cluster:
+                  show: true
+                  cpu: true
+                  memory: true
+                  showLabel: true
+                  label: cluster
+                nodes:
+                  show: true
+                  cpu: true
+                  memory: true
+                  showLabel: true
+          kubernetes.yaml: |
+            mode: cluster
+          docker.yaml: ""
+          custom.css: ""
+          custom.js: ""

--- a/kubernetes/apps/default/homepage/app/httproute.yaml
+++ b/kubernetes/apps/default/homepage/app/httproute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homepage
+  namespace: default
+spec:
+  parentRefs:
+    - name: internal
+      namespace: networking
+      sectionName: https
+  hostnames:
+    - "homepage.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: homepage
+          port: 3000

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./rbac.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/homepage/app/rbac.yaml
+++ b/kubernetes/apps/default/homepage/app/rbac.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homepage
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+      - endpoints
+    verbs: [get, list]
+  - apiGroups: ["networking.k8s.io"]
+    resources: [ingresses]
+    verbs: [get, list]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: [gateways, httproutes]
+    verbs: [get, list]
+  - apiGroups: ["traefik.containo.us", "traefik.io"]
+    resources: [ingressroutes]
+    verbs: [get, list]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: [nodes, pods]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homepage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homepage
+subjects:
+  - kind: ServiceAccount
+    name: homepage
+    namespace: default

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app homepage
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/homepage/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./distcc/ks.yaml
   - ./echo-server/ks.yaml
   - ./hajimari/ks.yaml
+  - ./homepage/ks.yaml
   - ./immich/ks.yaml
   - ./n8n/ks.yaml
   - ./ocis/ks.yaml


### PR DESCRIPTION
## Summary
- Adds [Homepage](https://gethomepage.dev) (`gethomepage/homepage`) as a modern, actively-maintained replacement candidate for the abandoned hajimari (last release 2022).
- Deployed via the repo-standard `bjw-s` `app-template` 5.0.0 + Gateway API HTTPRoute on `internal/https` — mirrors readeck/etc.
- Hajimari is **left in place** for side-by-side use; cutover and removal will be a follow-up PR once parity is confirmed.

## What's mirrored from hajimari
- Title: "Rasp K3s", dark/slate theme (closest neutral to `tron`).
- Custom apps: Transmission (Media), PagerDuty (Monitoring).
- Bookmarks: `k8s-at-home` and `Tech` groups, same entries.
- Search bar off, `lan-only: "true"` pod label preserved.
- Resources: 25m / 128Mi req, 256Mi limit.

## Behavior differences worth knowing
- **Auto-discovery is opt-in.** Hajimari had `defaultEnable: true` + `namespaceSelector.any: true` — every ingress lit up by default. Homepage requires `gethomepage.dev/enabled: "true"` plus `name`/`group`/`icon` annotations per Service or HTTPRoute. Annotating apps will be a follow-up.
- **No `tron` theme equivalent.** Using `dark` + `color: slate`; trivial to tweak in the ConfigMap.
- **Kubernetes discovery RBAC** included (services, ingresses, gateways, httproutes, metrics).

## Files
- `kubernetes/apps/default/homepage/ks.yaml`
- `kubernetes/apps/default/homepage/app/{kustomization,helmrelease,rbac,httproute}.yaml`
- `kubernetes/apps/default/kustomization.yaml` — wired into namespace.

Image pinned: `ghcr.io/gethomepage/homepage:v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401`.

## Test plan
- [ ] Flux reconciles the new Kustomization (`flux get ks -n flux-system cluster-apps-homepage`).
- [ ] HelmRelease reaches Ready (`flux get hr -n default homepage`).
- [ ] Pod becomes ready; logs free of RBAC errors against `services`, `httproutes`, `gateways`.
- [ ] `https://homepage.${SECRET_DOMAIN}` loads on LAN; bookmarks and the two manual service entries render.
- [ ] Confirm kubernetes widget shows cluster + node CPU/memory.
- [ ] Decide on cutover: annotate apps with `gethomepage.dev/*` for discovery parity, then open follow-up to remove hajimari + its HelmRepository.