### PR TITLE
fix: k8s-gateway watch scope + homepage configMap reference

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
           - path: /app/config/logs
       config:
         type: configMap
-        name: homepage-config
+        identifier: config
         globalMounts:
           - path: /app/config/settings.yaml
             subPath: settings.yaml

--- a/kubernetes/apps/networking/k8s-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/k8s-gateway/app/helmrelease.yaml
@@ -29,6 +29,9 @@ spec:
     fullnameOverride: k8s-gateway
     domain: "${SECRET_DOMAIN}"
     ttl: 1
+    # Restrict watched resources so the chart doesn't try to list TLSRoute/GRPCRoute
+    # CRDs that aren't installed. Drop "Ingress" in Phase 6 once nginx is gone.
+    watchedResources: ["HTTPRoute", "Ingress"]
     service:
       type: LoadBalancer
       port: 53


### PR DESCRIPTION
Two unrelated fallout fixes after #2578 (Cilium Gateway API migration phases 0-1) and #2579 (homepage dashboard).

## k8s-gateway watched resources

When HTTPRoutes were introduced in #2578, k8s-gateway auto-detected Gateway API and started watching every Gateway API resource type — including `TLSRoute` and `GRPCRoute`, whose CRDs aren't installed. The reflector failed with `the server could not find the requested resource`, and DNS queries returned SERVFAIL.

Fix: explicit `watchedResources: ["HTTPRoute", "Ingress"]`. Drop `Ingress` in Phase 6 once nginx is removed.

## Homepage configMap identifier

`persistence.config.name: homepage-config` referenced a ConfigMap that doesn't exist — the chart-generated ConfigMap is just `homepage`. Pod was stuck in `ContainerCreating` with `MountVolume.SetUp failed: configmap "homepage-config" not found`. Switching to `identifier: config` makes it reference the in-chart `configMaps.config:` block by key, which is the v5 idiomatic form.

## Test plan

- [ ] After Flux reconcile: k8s-gateway logs stop showing `TLSRoute`/`GRPCRoute` reflector errors
- [ ] `dig @192.168.100.220 hajimari.\${SECRET_DOMAIN} +short` returns `192.168.100.226`
- [ ] `dig @192.168.100.220 radarr.\${SECRET_DOMAIN} +short` still returns `192.168.100.221` (nginx, until Phase 6)
- [ ] homepage pod reaches `Running 1/1` and `https://homepage.\${SECRET_DOMAIN}` serves the dashboard