### PR TITLE
fix(default): correct homepage configMap reference to release-name

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
           - path: /app/config/logs
       config:
         type: configMap
-        identifier: config
+        name: homepage
         globalMounts:
           - path: /app/config/settings.yaml
             subPath: settings.yaml


### PR DESCRIPTION
Corrigendum to #2580. My previous attempt used `identifier: config` which doesn't produce the expected ConfigMap name on bjw-s app-template v5.

Looking at `kubernetes/apps/monitoring/mimir/app/helmrelease.yaml:182` for a working pattern: the chart names ConfigMaps generated by `configMaps.<key>:` after the release name, not `<release>-<key>`. Live cluster confirms: `kubectl -n default get cm homepage` (8 data keys) exists; `homepage-config` does not. Pod is stuck `0/1 ContainerCreating` with `MountVolume.SetUp failed for volume "config": configmap "homepage-config" not found`.

Switch `persistence.config.name: homepage-config` → `name: homepage` to point at the real ConfigMap.

## Test plan
- [ ] homepage pod reaches `Running 1/1` (no more `FailedMount: configmap not found`)
- [ ] `https://homepage.${SECRET_DOMAIN}` (via internal Gateway) serves the dashboard