### PR TITLE
feat(media): add flaresolverr

### DIFF
--- a/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flaresolverr
+  namespace: media
+spec:
+  releaseName: flaresolverr
+  chartRef:
+    kind: OCIRepository
+    name: flaresolverr
+    namespace: flux-system
+  interval: 50m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # see https://github.com/truecharts/public/blob/master/charts/stable/flaresolverr/values.yaml
+  values:
+    resources:
+      limits:
+        cpu: 800m
+        memory: 768Mi
+      requests:
+        cpu: 50m
+        memory: 768Mi
+    securityContext:
+      container:
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+
+    service:
+      metrics:
+        enabled: true
+        type: "ClusterIP"
+        ports:
+          metrics:
+            enabled: true
+            port: 8192
+            targetPort: 8192
+
+    workload:
+      main:
+        strategy: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0
+          maxSurge: 1
+        podSpec:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "8192"
+            prometheus.io/path: "/metrics"
+          containers:
+            main:
+              env:
+                # TEST_URL: "https://www.google.com"
+                # BROWSER_TIMEOUT: 40000
+                HEADLESS: true
+                LOG_LEVEL: info
+                LOG_HTML: false
+                # At this time none of the captcha solvers work, defaults to none.
+                CAPTCHA_SOLVER: none
+                PROMETHEUS_ENABLED: true
+                PROMETHEUS_PORT: 8192
+
+    persistence:
+      config:
+        enabled: true
+        type: emptyDir
+        mountPath: "/config"

--- a/kubernetes/apps/media/flaresolverr/app/kustomization.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/flaresolverr/ks.yaml
+++ b/kubernetes/apps/media/flaresolverr/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flaresolverr
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/media/flaresolverr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./bazarr/ks.yaml
+  - ./flaresolverr/ks.yaml
   - ./jellyfin/ks.yaml
   - ./seer/ks.yaml
   - ./metube/ks.yaml

--- a/kubernetes/flux/repositories/oci/flaresolverr-oci.yaml
+++ b/kubernetes/flux/repositories/oci/flaresolverr-oci.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flaresolverr
+  namespace: flux-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 16.14.6
+  url: oci://oci.trueforge.org/truecharts/flaresolverr

--- a/kubernetes/flux/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/repositories/oci/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./bjw-s-oci.yaml
   - ./cnpg-barman-cloud-oci.yaml
   - ./cnpg-oci.yaml
+  - ./flaresolverr-oci.yaml
   - ./headlamp-oci.yaml


### PR DESCRIPTION
## Summary
- Adds flaresolverr HelmRelease + Flux Kustomization for the media namespace
- Adds the flaresolverr OCI repository to flux repositories

## Test plan
- [x] Flux reconciles the OCIRepository
- [x] flaresolverr HelmRelease becomes Ready
- [x] prowlarr/sonarr/radarr can hit the flaresolverr service endpoint