### PR TITLE
feat(ansible): add openwrt-router playbook and role

### DIFF
--- a/ansible/inventory/group_vars/openwrt/dhcp.sops.yml
+++ b/ansible/inventory/group_vars/openwrt/dhcp.sops.yml
@@ -1,0 +1,70 @@
+#ENC[AES256_GCM,data:ThXO90pyMKIy/VF6lQEcVasv,iv:3Tk9nAeF7N48z25kFwwNY2wAcu1p+yyp8DBHIghP/D4=,tag:+q/DefgxjQJSTrUMK9k7ng==,type:comment]
+#ENC[AES256_GCM,data:Ie01Xkzl5B7nrVm4f/kB3d29Uq014G0HpNSKLlRKg6U+dbcDrZE1e2N3w6D7NRbCrplRmxYJ+kNHbtyi3RiPJsrbNkumJJQQm+EqUBvxAD0OEw==,iv:vB3O4O9F2pmhnsdGWp3drv4mu4Vkkt1U0CJT+flyCFE=,tag:rLCblXTEL4i8fk4a7rqWQQ==,type:comment]
+#ENC[AES256_GCM,data:NPMM4dltEZUrKDLHWgTyuyRhioX3ALAMDz+qHoAwe6/4DKiIihU+TXEz3cpP1rGx7wsaAJILKs18u6eu3PIg3A9IRG7gRKRnuvo+XMg=,iv:DWMn8Sg/E1gwJ16ZiRaPQKBPIufyqGJjQosfuyzmGms=,tag:cuCqkOHg17JbBomsNr60ZA==,type:comment]
+#ENC[AES256_GCM,data:Uiqe/Vn0wz/grex0gPAhzSqgDK50Hps=,iv:RKnNPuAqyl6li0XJM6lRte9LrsTjMVa/wcjrgB9O9d0=,tag:aPdtWTthrIXUTVMnk6ijtA==,type:comment]
+#ENC[AES256_GCM,data:Ms6TYqkHv6eb32+rX1exNgFQscz2TqBOLs0/dkjor0w4kHlX7jMlWm0pr373pvSTp16uMO85w/ysGfCTG5IW+0Dh3sLAcnDGofbgxG8=,iv:0EbY129vxQJLi1agMaIY7hGeimlUv5nropLGmRkJis0=,tag:G2oCXD9QZHBD/SCxmMhNJQ==,type:comment]
+#ENC[AES256_GCM,data:6qTHDwSzJ4cMMbzVGA14mggWRpCfx03RgZOSOgYCW511MGfJfa+agJpsDCjbRRfAEV666f8A0S78BaRBgod/,iv:9spnviI7qQ3ys9B6G8d7lsHvBvEfVb15EZZSruRKEaE=,tag:dRQDzHGnz3HCtyRTIvFsAQ==,type:comment]
+#ENC[AES256_GCM,data:+jpHyfbCjRMiJApRvBVE61n2l+SGI2pUC7QUNInhgDzzHNGLXl81fUhjxFp+qCh42fwACv/gc5jkKMQNglswDlp1CEVTruaXvG/QVJNT+0I=,iv:W5RqCdFv5XKGW3b0Za98yuyh9K4HKKa1et+LrFvxACc=,tag:z3Yh5hxtfWRrOZ6ObyZ6aQ==,type:comment]
+#ENC[AES256_GCM,data:9CT9Dd5voit3b8GYJAS2HLNj078jxpokrgb4A5HoGzH5jQrmSZnJs1UBAzrsPZmSA8svKnw3W4UsdWkB+16sKDGWzF1NU2BaMw==,iv:cGr1RokF7o5XP4otYdGMyRUpyJhE22b0tRs0cfBj7Es=,tag:0G1dHvDbC4u3T254yc9PEA==,type:comment]
+#
+#ENC[AES256_GCM,data:VQZRozd3h0O6kpk7hnbXNN7jXe5gm5A4AxJUq10ZnkGzCU4GIs8C5C2SDlNlHUrscFfpiI+rZC750AK7fsfdNcEkg+lz25lHWA==,iv:IsH9IGyL7JEVEVZrQbXLvE8VMaxhXPwdjoYMduXGVEU=,tag:vBn0z0kts+YbSEy3HHFMiQ==,type:comment]
+dhcp_reservations:
+    - name: ENC[AES256_GCM,data:1ii+ShvNHQ==,iv:axDE1OyKXZb2uT/DN0g/2kmv2P7kS0E7JM6+OC8WOD4=,tag:5aDu18yw21jiT3a6ikBBbA==,type:str]
+      mac: ENC[AES256_GCM,data:C+4BQj0wFhNT1dVZHb/Ck+o=,iv:MrRXuG39WZ9VfzeOz/lHniUXjV6BnicR+HKZvCbPBj4=,tag:HlJQfszmvSNk5JcNoOk4Lg==,type:str]
+      ip: ENC[AES256_GCM,data:H+aBpYmwuYyxnyE5Do/i,iv:DcE5LwaxnpMsotR1T0QtCO/tjtpMah/btX+VDQB0veM=,tag:cPs9MWF/YUsu0+iYqlQSGg==,type:str]
+    - name: ENC[AES256_GCM,data:oyht4C7fW786oQXT,iv:yLvict4oNoNt05cemqzJpQ3MH0BgeJte7VmXCSf37E4=,tag:UanvflV+qaoCNem37QG6Ng==,type:str]
+      mac: ENC[AES256_GCM,data:eRFFEy0FvyKNOjgLTR7WSUs=,iv:G0os/bzvuVLmObK4OttDgxs2SqQ2/txAUZxfgqKRMkY=,tag:MmaCZVfA4DP1S9j/RvGD4A==,type:str]
+      ip: ENC[AES256_GCM,data:lc34sjyZziH0KBLOA0U=,iv:HtS7WtC/uPPHLvwnZiTyhKrS/3wNrsHMzOmoASG7V6U=,tag:h16O/oCd3zJsIgIhHcUDhQ==,type:str]
+    - name: ENC[AES256_GCM,data:/o88L2lWwA==,iv:YnfiVv5ApU86Q8kWEPN2r+YCwMn7k9pznOlkDu/QlHk=,tag:7Tn46N71Rdha92qsbYQZ6A==,type:str]
+      mac: ENC[AES256_GCM,data:W3Cm3tLSK2A5J9fuVi/yrTw=,iv:MLK5W62MyWh1ETdZQevi4YM9JsLj0loUqI5UjTVxsHM=,tag:nHCEkYzYE/nl6x7HsVtpRQ==,type:str]
+      ip: ENC[AES256_GCM,data:XcLa/q9LI/K9lVjgysHZ,iv:zSaBzgp4FV6QhFq/vt1bPO2vi2uxpTI48jxFKswM8Ng=,tag:viMbP8lPkCZ+R2luAWQa3A==,type:str]
+    - name: ENC[AES256_GCM,data:Q82yjB3V9A==,iv:mDeQ/GdALKAaqvG7tJDWQ1SXynSJ2QrGXVjUVar/Ns8=,tag:BU1jifcioZYOsxOyVlr9Aw==,type:str]
+      mac: ENC[AES256_GCM,data:fU7TJx5cT8eFb0AlIZNzq6E=,iv:j5LgfzYQG5nQaRZCwdfQyR5wBcSW6vcIK0pu2AHGjCs=,tag:HbxW9ijH5iTSJ/pv92ABRQ==,type:str]
+      ip: ENC[AES256_GCM,data:VMhQYxakT351TqgRQXEz,iv:iEhrAQwo0/5U+s6LM1hh3aXHtb8KtX4nRYuHAZeLhBw=,tag:1lFTWUgvy34ghD1EPezWoA==,type:str]
+    - name: ENC[AES256_GCM,data:+EUr+SQLJw==,iv:uQ7pl9wrm7LANflBPBtPqe7AlvJJ5AxJ3udNSuBCGw4=,tag:+sNkF2rvWdl8tg9Q6vh0tg==,type:str]
+      mac: ENC[AES256_GCM,data:KApxgn9lgcj4GyzCwgC2T2Q=,iv:cOSJU6k3uSnuguYYywXlg9Z9FK3WOcOeWQluMS9h5Ck=,tag:ej50TtAo46WiJ2MI1dxKTA==,type:str]
+      ip: ENC[AES256_GCM,data:pPG9HB8xsMk9CNOxZW4A,iv:Qt6Qg45YiiFxkN9FC9jlFqdKOY1jeYWb1uPajn8apCU=,tag:jDOsCIlA7YDzkRhqK7SsxA==,type:str]
+    - name: ENC[AES256_GCM,data:kR2V/+zi2A==,iv:1hDuLKcNGKjzfxrIBixlXccrQgAqZQwQ9oAopuZwv90=,tag:oC6uzWzbTxJFUsNYJprGOw==,type:str]
+      mac: ENC[AES256_GCM,data:B9KmZMJEWg8CH566R0WZjsA=,iv:Fms9ZrjinJ1eRSaDx3dCKneBtkYoOMB0I3/aYEOVQPI=,tag:5nAYGMi7QwKpsTxcmVz87Q==,type:str]
+      ip: ENC[AES256_GCM,data:rzOR/sBSSR9D1GFsQ/0h,iv:c90KgzkcJTbnHA7X9z4F+THtpyiq894AjFbrgjgjLmo=,tag:68sEd/C4tyID2SGYQm/57Q==,type:str]
+    - name: ENC[AES256_GCM,data:WywbFp+jlQ==,iv:OTEvdlb8kBKTxlsUl6XFEQDY0QKVUVNZ1aQA+fr8Z60=,tag:jBje3IZdpIVcTKl3b5rbWw==,type:str]
+      mac: ENC[AES256_GCM,data:qC3dVkl55gPzcjiJHe7QQuQ=,iv:PB5kkH05EvFCcDm7aex7jxKzrcw0rg6odt/7zUEmlws=,tag:O6fa2ZwN3E1hS7XxlbvVzA==,type:str]
+      ip: ENC[AES256_GCM,data:EM8dAyiG6WlLle+dJVIn,iv:6osl9WWrBXOffHBXARXdH5Q6PvKatHmGqJg6zoETwZc=,tag:weWIwRZklb8k0FwO90S9HA==,type:str]
+    - name: ENC[AES256_GCM,data:zY9p/c7kFUwZ,iv:GF5SY6mNVRb/GkE5GkAWjvKKVXAh2dO+NtZI4+NO3Bk=,tag:blWF2kTPh3jxM9nwGKP7RA==,type:str]
+      mac: ENC[AES256_GCM,data:ThD54pksm/eH5ZPv0N/AhoA=,iv:zoCelDD/qBINGB2epmE/Zl/ujOSstQmaJneeZv6O/nQ=,tag:ypB+jdXPN8p3kVX6ajkA3g==,type:str]
+      ip: ENC[AES256_GCM,data:KEn8rVtksyP0JY2lGlw=,iv:WRQyd4DM3D+SakVGVPWR4FaRo+FfMUi7B/KXxBaXAcI=,tag:knT9g56jVc6QSczVxHE2ZA==,type:str]
+    - name: ENC[AES256_GCM,data:/eTt24zo+LS/ssY=,iv:oXFZQvfYL7q2owl6MTWS6u0Z30u595tE6++aiB2TNoo=,tag:RDyRUwBnF6lg9zYgCLbjWQ==,type:str]
+      mac: ENC[AES256_GCM,data:k/fF4aBeWZKhjTvd2bjXJ/g=,iv:2lQdvqf2okD5OSpT4kYR8HaQy/Fv3Msp0n3Tnjphsjk=,tag:wJVsI7dQbPFe/9rP27pwKw==,type:str]
+      ip: ENC[AES256_GCM,data:63rVakwpo/m3yXtxuL8=,iv:0ETAzIItum+K5m5GhQ3hlfv+TYQ/jYrRMMAR2JiGk6o=,tag:+XkCqlJi8PUh+h1znMFxug==,type:str]
+    - name: ENC[AES256_GCM,data:M7kclJtZK6Vls5+ud2IBHdNt/adTnKH0Nm7MfiIy,iv:LkXdN4l9D7zRs8qrp1noPCvKP7EZpAAnoZosy3zj+r8=,tag:s1EHPPm7cJOY8Ua9tT52oQ==,type:str]
+      mac: ENC[AES256_GCM,data:D+CE2RBFNiKuswTzSL0jwwE=,iv:cLi40Z/VV6cKr5JJ8D3ctXUErXfF2B0o0EEH0WfLYD8=,tag:p6aXU3n5iLBNEuh9auiutQ==,type:str]
+      ip: ENC[AES256_GCM,data:73UqhpMsLwNGzT3vwG8=,iv:ZWsiW8JLl6F7ehZTKb07/jKKzn8RBZdDnRNn9g0j2mA=,tag:Qs2dC9rEGrMF35/QJoLM+g==,type:str]
+    - name: ENC[AES256_GCM,data:twNhGSkeb90k5w==,iv:ElHu/EHcwiEotmlq1L7Q4Lksl+L174zloBNWDG4DIqg=,tag:x0jlr9StcJt5+S76g9iWbg==,type:str]
+      mac: ENC[AES256_GCM,data:HKutDl5Lz+zCuNWfghablBY=,iv:CaTWNchB7DzTKABB0ghVvxxARo0VWFcemEMAhIi7Tj0=,tag:h+Dh1l9vmLYmhCldgDc09A==,type:str]
+      ip: ENC[AES256_GCM,data:d/mHv2A4Hvl2Qkmot0c=,iv:y2tvJo5zP/GCy14IgtQl0ObPhszQAaVCgrGjWhR3QuU=,tag:ALsrMzwugrefZomJ2q28HA==,type:str]
+    - name: ENC[AES256_GCM,data:UyEjcgzUO2w935MFhS8=,iv:7BBhHPtNEewvm290isv1218tJH2Z6ANyR8utjNGzBiE=,tag:oK0j2nJcai0qxjeJ5z0IHg==,type:str]
+      mac: ENC[AES256_GCM,data:X1o2tzZtETAFAbDbJjSBRyk=,iv:/mdqtHF9lt0xuarrCdki0N2mSEAyTUZB6H9lsoTk9Js=,tag:k+u9MCwlTaAvbWu4zFPsIQ==,type:str]
+      ip: ENC[AES256_GCM,data:TOTzFD6Vcmrb+DC4tnjv,iv:PfQ1CIsd2/FG/smXLGeSzmSTRbSkQXAP+wdd3tXFdoQ=,tag:pTKQ+X1jxMWUcs1sSBh+aQ==,type:str]
+    #ENC[AES256_GCM,data:eUZeFMVQrD8Z0/NB2nJJqrQQwO+GoggqKPTFmOYVxB3BcqDyhnSADKrZrd85sxTd0qPng0l4,iv:X9uJgayrmR2MA6ub5p25XR22kMtAwrBwmIxUBp84ukQ=,tag:GdtVSHFn832mMds9Po1n9Q==,type:comment]
+    - name: ENC[AES256_GCM,data:S2Xq+hvjSlb7Fb8SbxY=,iv:ZNoAS1ZnnvaLvkhz3LZkr5xBXqCLtV/joEfIGQhGM8U=,tag:fKwpSVAnr7wmDhot6OjrXg==,type:str]
+      mac: ENC[AES256_GCM,data:aIhL8q/ItjF7SWCjixwEjKo=,iv:WQPtg///Z1lC+6aLLxEUIuSq1XsWKqGXvhbTFPuZplI=,tag:dU2jX/+5kd4Pqrm6v2WiGA==,type:str]
+      ip: ENC[AES256_GCM,data:9gFSprj1dwhbYkeLa5w=,iv:GMp5SRVC3t4Ru5R3UbbZvH5cabX+qNAaxRtreJEmhyo=,tag:CZNUSK/m5we/bxflEmrAgQ==,type:str]
+    #ENC[AES256_GCM,data:yyX5dzxxpTGEEBP/YVxC5Ep8s6RtM3foaVfUtDtPj97A1bIPAx0cOjshtEwQOKsHNuuYLw==,iv:PTCYKW2KNUmiBvPLNtbRGeGi71V08lqPywn5DRH0v2Y=,tag:40C4JrolCNA03S37cwHRhQ==,type:comment]
+    - name: ENC[AES256_GCM,data:SPHPuqzSWg==,iv:8MTA7ZNBRPYMBQ0DGVELhg12fG83SDY+iW9j6sVTD/U=,tag:pYBee+1LMzUE3hVR9OOzow==,type:str]
+      mac: ENC[AES256_GCM,data:J8UeXOTpBCFt3KrP7gUTSZw=,iv:VW5Wt9XXpw7kdomLYx8fyGniGkxYVUHdfy0qUwPKor0=,tag:pOMc0yePsQvM5ZekzGjsgQ==,type:str]
+      ip: ENC[AES256_GCM,data:rZREvmdHJq8a3kdUq2yg,iv:yLBXVckrdxEKEF7fh8fN9YJXjHS0hZKqv69WRemkVr8=,tag:zwzc6pQark+GPs7I3zokLA==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlbjFQcWhvaWcrOFpJNTYy
+            THRMejREMHF6TjcrcXRzSU4ybk1OSXlraERRCjNDZktvMStmc2RaL0VPSU9TYlZx
+            SGZhQ1dtendTSDNCNStzZEM1TEpSWWsKLS0tIGtDd2dTRWtXV2pZcDBBQlRSbXFk
+            dnl5dVdCN0x6WjY1bXJNYUw2a1g1ZDAKuaMgV9fhooX65we3zDUJW7hx7NUbkH3w
+            zzUByAMUAK75ttHUsXKsHXlWy1lvDQhlE5eSbrHRkTmw760Pwp1slQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-14T14:52:13Z"
+    mac: ENC[AES256_GCM,data:Va7lFACzDqtghlYa20Iogv5KGSyea2tZ6rbpK+YfXx7yZ7ipn5foRwwbQ0tWQ6GH8WgUu/N4HQufQ+6oLfu4VhcyP7lyRObkicALpdmZEiWnMSAcnHgj11+X8xhQkTKdZ1f4hyIuxKKv810UPCEkIVaqmQv0+s/HFcYrv6Nodac=,iv:zMiQuUr2UUH0KPX4jAQKuWinHn4mLv+VEfLsEJSf8Hc=,tag:tUxKGhP+UztpcmzPDlwZzA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -1,0 +1,38 @@
+---
+- name: Configure OpenWrt router
+  hosts: openwrt
+  gather_facts: false        # python-free per community.openwrt official guidance
+  any_errors_fatal: true
+  vars:
+    dns_domain: lan
+    opkg_packages:
+      # Prometheus node exporter + collectors
+      - prometheus-node-exporter-lua
+      - prometheus-node-exporter-lua-hostapd_stations
+      - prometheus-node-exporter-lua-hwmon
+      - prometheus-node-exporter-lua-nat_traffic
+      - prometheus-node-exporter-lua-netstat
+      - prometheus-node-exporter-lua-openwrt
+      - prometheus-node-exporter-lua-snmp6
+      - prometheus-node-exporter-lua-thermal
+      - prometheus-node-exporter-lua-uci_dhcp_host
+      - prometheus-node-exporter-lua-wifi
+      - prometheus-node-exporter-lua-wifi_stations
+      # Dynamic DNS
+      - ddns-scripts
+      - ddns-scripts-cloudflare
+      - ddns-scripts-noip
+      - ddns-scripts-services
+      - ddns-scripts-utils
+      # DNS debugging tools
+      - bind-tools
+      - drill
+    # dhcp_reservations comes from
+    # ansible/inventory/group_vars/openwrt/dhcp.sops.yml (sops-encrypted).
+    # Currently unmanaged on purpose:
+    #   - host[7]  tradfri          (no name)
+    #   - host[9]  kube-vip-invalid (no name)
+    #   - domain   mqtt.lan -> virtual hostname, no lease
+    #   - domain   console.gl-inet.com -> router self (vendor vanity)
+  roles:
+    - role: openwrt-router

--- a/ansible/roles/openwrt-router/defaults/main.yml
+++ b/ansible/roles/openwrt-router/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Reservations are defined on the playbook itself; this default keeps the
+# role safe to include without arguments and lets ansible-lint pass
+# role-structure checks.
+dhcp_reservations: []
+dns_domain: lan
+opkg_packages: []

--- a/ansible/roles/openwrt-router/handlers/main.yml
+++ b/ansible/roles/openwrt-router/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload dnsmasq
+  # raw, not ansible.builtin.command — we run python-free on this host.
+  ansible.builtin.raw: /etc/init.d/dnsmasq reload
+  changed_when: true

--- a/ansible/roles/openwrt-router/meta/main.yml
+++ b/ansible/roles/openwrt-router/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: thiagoalmeidasa
+  description: Configure an OpenWrt router via UCI (DHCP reservations and DNS hostnames)
+  license: MIT
+  min_ansible_version: "2.18"
+  platforms:
+    - name: OpenWrt
+      versions:
+        - all
+  galaxy_tags:
+    - networking
+    - openwrt
+    - dnsmasq
+dependencies: []

--- a/ansible/roles/openwrt-router/tasks/dhcp-reservations.yml
+++ b/ansible/roles/openwrt-router/tasks/dhcp-reservations.yml
@@ -1,0 +1,27 @@
+---
+# Additive only: we never call `absent` here, so unmanaged host sections on
+# the router are left untouched. MAC address is the natural unique key.
+
+- name: DHCP | Upsert host reservation
+  community.openwrt.uci:
+    command: section
+    config: dhcp
+    type: host
+    find:
+      mac: "{{ item.mac }}"
+    value: >-
+      {{
+        {'name': item.name, 'ip': item.ip}
+        | combine({'dns': item.dns} if item.dns is defined else {})
+      }}
+    set_find: true
+  loop: "{{ dhcp_reservations }}"
+  loop_control:
+    label: "{{ item.name }} ({{ item.mac }} -> {{ item.ip }})"
+  notify: Reload dnsmasq
+
+- name: DHCP | Commit dhcp config
+  community.openwrt.uci:
+    command: commit
+    config: dhcp
+  notify: Reload dnsmasq

--- a/ansible/roles/openwrt-router/tasks/dns-address-overrides.yml
+++ b/ansible/roles/openwrt-router/tasks/dns-address-overrides.yml
@@ -1,0 +1,33 @@
+---
+# Manages dnsmasq `address=/domain/ip` directives as a UCI list under
+# `dhcp.@dnsmasq[0].address`. Unlike the per-host `domain` sections
+# (dns-hostnames.yml, additive only), this list is treated declaratively:
+# the value of `dns_address_overrides` in the playbook IS the source of
+# truth. Entries not listed here will be removed on next run.
+
+- name: DNS | Build dnsmasq address directive list
+  ansible.builtin.set_fact:
+    dnsmasq_address_directives: >-
+      {{
+        dns_address_overrides
+        | map(attribute='domain')
+        | zip(dns_address_overrides | map(attribute='ip'))
+        | map('join', '/')
+        | map('regex_replace', '^', '/')
+        | list
+      }}
+
+- name: DNS | Set dnsmasq address overrides
+  community.openwrt.uci:
+    command: set
+    key: "dhcp.@dnsmasq[0].address"
+    value: "{{ dnsmasq_address_directives }}"
+  when: dnsmasq_address_directives | length > 0
+  notify: Reload dnsmasq
+
+- name: DNS | Commit dhcp config
+  community.openwrt.uci:
+    command: commit
+    config: dhcp
+  when: dnsmasq_address_directives | length > 0
+  notify: Reload dnsmasq

--- a/ansible/roles/openwrt-router/tasks/dns-hostnames.yml
+++ b/ansible/roles/openwrt-router/tasks/dns-hostnames.yml
@@ -1,0 +1,24 @@
+---
+# Mirrors the LuCI "Hostnames" tab — UCI `config domain` sections binding an
+# FQDN to an IP. Additive only: never `absent`, never `replace`.
+
+- name: DNS | Upsert hostname binding
+  community.openwrt.uci:
+    command: section
+    config: dhcp
+    type: domain
+    find:
+      name: "{{ item.hostname | default(item.name if '.' in item.name else item.name ~ '.' ~ (dns_domain | default('lan'))) }}"
+    value:
+      ip: "{{ item.ip }}"
+    set_find: true
+  loop: "{{ dhcp_reservations }}"
+  loop_control:
+    label: "{{ item.hostname | default(item.name if '.' in item.name else item.name ~ '.' ~ (dns_domain | default('lan'))) }} -> {{ item.ip }}"
+  notify: Reload dnsmasq
+
+- name: DNS | Commit dhcp config
+  community.openwrt.uci:
+    command: commit
+    config: dhcp
+  notify: Reload dnsmasq

--- a/ansible/roles/openwrt-router/tasks/main.yml
+++ b/ansible/roles/openwrt-router/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Packages | Ensure required packages
+  ansible.builtin.import_tasks: opkg-packages.yml
+  when: opkg_packages is defined and opkg_packages | length > 0
+
+- name: DHCP | Apply static reservations
+  ansible.builtin.import_tasks: dhcp-reservations.yml
+  when: dhcp_reservations is defined and dhcp_reservations | length > 0
+
+- name: DNS | Apply hostname bindings
+  ansible.builtin.import_tasks: dns-hostnames.yml
+  when: dhcp_reservations is defined and dhcp_reservations | length > 0

--- a/ansible/roles/openwrt-router/tasks/opkg-packages.yml
+++ b/ansible/roles/openwrt-router/tasks/opkg-packages.yml
@@ -1,0 +1,13 @@
+---
+- name: Packages | Update opkg cache
+  community.openwrt.opkg:
+    name: "*"
+    state: present
+    update_cache: true
+  changed_when: false
+
+- name: Packages | Ensure packages are installed
+  community.openwrt.opkg:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ opkg_packages }}"


### PR DESCRIPTION
## Summary
- Adds `playbooks/openwrt-router.yml` to configure OpenWrt routers via UCI
- Adds `roles/openwrt-router/` with tasks for opkg packages, DHCP reservations, and DNS hostnames
- Role runs without Python on the target (community.openwrt guidance: `gather_facts: false`)

## Notes
- The playbook targets `hosts: openwrt`. No `openwrt` group is defined in `ansible/inventory/hosts.yml` yet; that inventory entry is a separate change.
- `tasks/dns-address-overrides.yml` exists in the role but is not imported by `tasks/main.yml`. Intentional (kept for future use).

## Test plan
- [x] Add the OpenWrt host to inventory
- [x] Run \`ansible-playbook ansible/playbooks/openwrt-router.yml --check\` and inspect the diff
- [x] Apply, then verify DHCP leases and DNS resolution against \`192.168.100.1\`