### PR TITLE
fix(default): mount homepage SA token so kube widgets work

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -60,6 +60,7 @@ spec:
                 drop: [ALL]
 
     defaultPodOptions:
+      automountServiceAccountToken: true
       labels:
         lan-only: "true"
 


### PR DESCRIPTION
## Summary
- The homepage pod was running with `automountServiceAccountToken: false` (the bjw-s app-template v5 default when `serviceAccount` is set), so the kubernetes widget and ingress-list integration couldn't authenticate to the kube-API. Logs spammed `<widget> Error getting nodes: NaN undefined undefined` and `<ingress-list> Error getting ingresses: NaN undefined undefined` on every poll, making the dashboard sluggish.
- Opt in to token mounting via `defaultPodOptions.automountServiceAccountToken: true`. RBAC (ClusterRole `homepage`) already covers nodes, pods, services, ingresses, gateways/httproutes, and metrics — nothing else to change.

## Test plan
- [x] Flux reconciles the HelmRelease without error
- [x] `kubectl exec deploy/homepage -- ls /var/run/secrets/kubernetes.io/serviceaccount/` shows `token`, `ca.crt`, `namespace`
- [x] `kubectl logs deploy/homepage` no longer shows the `NaN undefined undefined` lines
- [x] Cluster + node CPU/memory widget renders on `https://homepage.${SECRET_DOMAIN}`
- [x] Dashboard load feels snappy again