### PR TITLE
feat(monitoring): enable Cilium prometheus metrics + chart dashboards

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -20,12 +20,23 @@ endpointRoutes:
   enabled: true
 envoy:
   enabled: true
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
   resources:
     requests:
       cpu: 20m
       memory: 128Mi
     limits:
       memory: 512Mi
+dashboards:
+  enabled: true
+  namespace: kube-system
+  label: grafana_dashboard
+  labelValue: "1"
+  annotations:
+    grafana_folder: Cilium
 hubble:
   enabled: false
 ipam:
@@ -44,6 +55,17 @@ localRedirectPolicy: true
 operator:
   replicas: 1
   rollOutPods: true
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  dashboards:
+    enabled: true
+    namespace: kube-system
+    label: grafana_dashboard
+    labelValue: "1"
+    annotations:
+      grafana_folder: Cilium
 rollOutCiliumPods: true
 routingMode: native
 securityContext:
@@ -68,6 +90,11 @@ gatewayAPI:
   enabled: true
   enableAlpn: true
   xffNumTrustedHops: 1
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    trustCRDsExist: true
 resources: # for agent
   requests:
     cpu: 32m


### PR DESCRIPTION
## Summary

- Enable cilium-agent, cilium-operator, cilium-envoy prometheus exporters + ServiceMonitors
- Enable chart-bundled Grafana dashboards (folder: Cilium)

## Test plan

- [ ] 3 ServiceMonitors render under kube-system
- [ ] Prometheus scrape targets `cilium-agent`/`cilium-operator`/`cilium-envoy` show `up`
- [ ] Grafana "Cilium" folder shows non-empty dashboards
- [ ] No restart loops on cilium-agent / cilium-envoy