### PR TITLE
feat(ansible): codify OpenWrt DNS overrides via openwrt-router role

### DIFF
--- a/ansible/inventory/group_vars/openwrt/vars.sops.yml
+++ b/ansible/inventory/group_vars/openwrt/vars.sops.yml
@@ -1,0 +1,18 @@
+#ENC[AES256_GCM,data:3DujcRiDCXA8SBMH86WxV+BSVndhp2nlg6ZE7JzpsmDLgFoNBFAnibSsXtCWLqJH81whS+8rkbVlnFCwPUp2TVvqykVvj+ZUgQQ/zCCswg==,iv:T3Ug/r4Pk+3nRduyhhyX5Qvotk9SmfYfhUnNwDsuwSo=,tag:+4Y63JthuP3Abqm/pS+hfA==,type:comment]
+#ENC[AES256_GCM,data:Qb8dB4pCc7qrQ83ab8Z3M9MJc6K8i3i7TRHnt8peEpjJDsnQmR4IepmyFY+GmiNpXEMctyWSalnj3VyNG1y6,iv:snOwR6UYcmc0Q/ueAboIx8BmR2y+xSGbUu1cCs1ocZA=,tag:govbUGO+GyqyOn/sVD8gnw==,type:comment]
+secret_domain: ENC[AES256_GCM,data:SQN9TDu5gydoyBGe2BVPfIrSORBc5WLkBA==,iv:+h+pEenUY+abzsWgtOiJcqAbHvi47rUqJIdNDSiS6Fg=,tag:LCG3INEX8TAPzowO2WY2dw==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFaGRheDRiVVNGNHI2Yk1U
+            b1pRTXk2TTFoTmRJbGwxRDJOZml4K1BUMVc0ClI1d1JZL3VDa1Fxb0NUcFhhWk4r
+            bGNjMWtxelB1ekJORXkwVldKeUNrek0KLS0tIHJpcWIwaGtkN1ovdnVTbldoQjN5
+            VnJrY1o2K1V5bGt2djV0ZHQ0WmFVSjQK3CiTRbDGY9q080bx1P4vkV/HRl3L1Srp
+            yhZhqbXTGAD6m087o849NTQSLlA5qEal61L9L9dF8ZPHCGWEddx5ww==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-14T18:11:36Z"
+    mac: ENC[AES256_GCM,data:lJdLou71xmA9CilmTeU7wVcneTPtrI4peLCGargmYkKSzb8SseEckiR5iNAFvxK2z8/J1uFxrcFefZjEE7dpf/XytVzTZVe9t86fX4U9JOKvc+8fBwbiqz8XqLDI/CscdKKyY5Yw+MxTpAmQrLrYhnZPr47Yq92F0HXTD/q3Y5Y=,iv:z2F+EjLWVRrhD1SktNVqYhgEmVSjAmdQ16iNOvOK0+E=,tag:C7yZNX7yLR95C/nFNU8kSQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/ansible/inventory/host_vars/router.lan.sops.yml
+++ b/ansible/inventory/host_vars/router.lan.sops.yml
@@ -1,0 +1,19 @@
+ansible_host: ENC[AES256_GCM,data:1Vo53StyLZOY+lPN9w==,iv:m6CiLYT+myEsVNI22ourdNfz9xmOdDjc4jKfbWnffE8=,tag:33N6q9nQd6VZXoHvuLurhw==,type:str]
+ansible_user: ENC[AES256_GCM,data:0VOJxg==,iv:ZfKYzkPAcyy42afwTAaxFwPJUev5kFwkXQuk3ydfQug=,tag:XUBjqJf6o91Wz9BIjQHJcg==,type:str]
+ansible_connection: ENC[AES256_GCM,data:Zr0QvjgYNGrI5pLQp3W63L8IuPUBOUpnByGHLsU=,iv:QDKBYSLF9lZq43Zbs6SkCeje8Vb5yRaR6dUIJPacay4=,tag:0U/ixqj4tFtSt/8aF1/bKA==,type:str]
+ansible_network_os: ENC[AES256_GCM,data:meReGoP+TNFSDBTmQARAqTSZXH8yTOYboA==,iv:6r4WY3juKhdf9kkUQFZ5S+xjgAkm4pfXCDiJjvSGE1w=,tag:V4l6BDpyXW3LucE9AesbRg==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDT1EwVFBZVUFzSVJITmtZ
+            NFdmeWhDc1VhcG55bzNsdFl1MEMzeHJCblFzCms1QmVRV1Zyd3NjcXRVSE82WnJN
+            aWlWRHBQM1RpaWZxVkZKeFJUcUoxZmsKLS0tIEV2RWVQdEZ1Ym9aNTJjN0I5a2or
+            WWZSNjFJazZydTlySW8va3V4cHVTb0EKb2un29bHd5BzQUm84iRK2NyomOcMsvtX
+            +rywQ+ZbKO9qJVOO2Da8r8BvzLTxsRzAqudXw1Ecjb7CdFd7C4ycDw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-14T18:14:01Z"
+    mac: ENC[AES256_GCM,data:wGqqI4Fltf12tkYeP+SbS6aWUKA2V63bel05qEpyetczcfDQLuDgNjqBJzmXKIk8mknD9rnFnFa3k5E+JhEjZA/nMIgWGd7nQpEDZCqDgIujQasDqm9P/seZMxRIB0kjeygCF5FvtiChKXuVQQoOeNzD76QelA6rYB3wBoRo4Pc=,iv:58Lt41WLFeaDniwKWf6YBLCDBYLYxWerQkOGMYQY+eA=,tag:P24iuRghEupIRdvMiukPWA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -25,3 +25,6 @@ kubernetes:
         cn8.lan:
           ansible_host: 192.168.100.108
           ansible_user: ubuntu
+openwrt:
+  hosts:
+    router.lan:

--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -34,5 +34,11 @@
     #   - host[9]  kube-vip-invalid (no name)
     #   - domain   mqtt.lan -> virtual hostname, no lease
     #   - domain   console.gl-inet.com -> router self (vendor vanity)
+    dns_address_overrides:
+      # Internal Cilium gateway (GATEWAY_INTERNAL_ADDR in
+      # kubernetes/flux/vars/cluster-settings.yaml) — the only LAN-routable
+      # cluster entrypoint. Wildcard covers every LAN-only homelab subdomain.
+      # `secret_domain` lives in inventory/group_vars/openwrt/vars.sops.yml.
+      - { domain: "{{ secret_domain }}", ip: 192.168.100.226 }
   roles:
     - role: openwrt-router

--- a/ansible/roles/openwrt-router/defaults/main.yml
+++ b/ansible/roles/openwrt-router/defaults/main.yml
@@ -3,5 +3,6 @@
 # role safe to include without arguments and lets ansible-lint pass
 # role-structure checks.
 dhcp_reservations: []
+dns_address_overrides: []
 dns_domain: lan
 opkg_packages: []

--- a/ansible/roles/openwrt-router/tasks/main.yml
+++ b/ansible/roles/openwrt-router/tasks/main.yml
@@ -10,3 +10,7 @@
 - name: DNS | Apply hostname bindings
   ansible.builtin.import_tasks: dns-hostnames.yml
   when: dhcp_reservations is defined and dhcp_reservations | length > 0
+
+- name: DNS | Apply dnsmasq address overrides
+  ansible.builtin.import_tasks: dns-address-overrides.yml
+  when: dns_address_overrides is defined and dns_address_overrides | length > 0


### PR DESCRIPTION
## Summary
- Wires the existing `dns-address-overrides.yml` into `tasks/main.yml` and adds the `dns_address_overrides` default.
- Codifies the lone LAN-side wildcard `home399.thiagoalmeida.xyz` → `192.168.100.226` (previously set manually via LuCI).
- Adds the `openwrt` group with `router.lan` so the playbook can actually run.

Declarative: stale router entries (e.g. legacy `192.168.100.221` from the retired nginx VIP) get removed on first apply.

## Test plan
- [x] `ansible-playbook playbooks/openwrt-router.yml --check --diff`
