### PR TITLE
fix(networking): publish external-gateway HTTPRoutes via external-dns

### DIFF
--- a/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
@@ -41,7 +41,6 @@ spec:
             name: external-dns-secret
             key: api-key
     extraArgs:
-      - --annotation-filter=external-dns.alpha.kubernetes.io/target
       - --cloudflare-proxied
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint


### PR DESCRIPTION
## Summary
Drops `--annotation-filter=external-dns.alpha.kubernetes.io/target` from external-dns.

The HTTPRoutes migrated from ingress-nginx don't carry that annotation (only the parent `Gateway` does, and the filter applies to source resources), so external-dns was publishing nothing for `*.thiagoalmeida.xyz`. Scope is still constrained by `--gateway-name=external`.

## Test plan
- [ ] `dig notes.thiagoalmeida.xyz @1.1.1.1` returns a Cloudflare-proxied IP within one reconcile loop
- [ ] external-dns logs show `CREATE` events for the previously-missing CNAMEs