### PR TITLE
feat(networking): template-align external gateway + cloudflared

### DIFF
--- a/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
@@ -8,6 +8,9 @@ metadata:
     external-dns.alpha.kubernetes.io/target: "ingress.${PUBLIC_DOMAIN}"
 spec:
   gatewayClassName: cilium
+  infrastructure:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: "ingress.${PUBLIC_DOMAIN}"
   listeners:
     - name: http
       protocol: HTTP

--- a/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
@@ -8,5 +8,8 @@
 # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
 ingress:
   - hostname: "*.${PUBLIC_DOMAIN}"
+    originRequest:
+      http2Origin: true
+      originServerName: "ingress.${PUBLIC_DOMAIN}"
     service: https://cilium-gateway-external.networking.svc.cluster.local:443
   - service: http_status:404


### PR DESCRIPTION
## Summary

- Add `infrastructure.annotations.external-dns.alpha.kubernetes.io/hostname` to the `external` Gateway (mirrors the template; no-op today since external-dns has no `service` source).
- Add `originRequest.http2Origin` and `originRequest.originServerName` to the cloudflared ingress block.