### PR TITLE
fix(flux): cnpg PrometheusRule webhook compat + pin seer digest

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
             severity: critical
           annotations:
             summary: CNPG last backup too old ({{ $labels.pod }})
-            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 26 hours.\n  VALUE = {{ $value | humanizeSeconds }}"
+            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 26 hours.\n  VALUE = {{ $value }}s"
 
         - alert: CNPGWALArchivingFailing
           expr: |
@@ -37,7 +37,7 @@ spec:
             severity: critical
           annotations:
             summary: CNPG WAL archiving lagging ({{ $labels.pod }})
-            description: "No WAL archived in over 1 hour for {{ $labels.namespace }}/{{ $labels.pod }}. Point-in-time recovery is at risk.\n  VALUE = {{ $value | humanizeSeconds }}"
+            description: "No WAL archived in over 1 hour for {{ $labels.namespace }}/{{ $labels.pod }}. Point-in-time recovery is at risk.\n  VALUE = {{ $value }}s"
 
         - alert: CNPGClusterNotHealthy
           expr: |

--- a/kubernetes/apps/media/seer/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seer/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/seerr-team/seerr
-              tag: v3.2.0
+              tag: v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
             env:
               TZ: ${TIMEZONE}
               LOG_LEVEL: "info"


### PR DESCRIPTION
## Summary
- Drop `humanizeSeconds` filter from `cnpg-rules` PrometheusRule descriptions — the prometheus-operator admission webhook no longer accepts it, blocking the `cluster-apps-cnpg-default` Kustomization.
- Pin `ghcr.io/seerr-team/seerr:v3.2.0` to its sha256 digest.

## Test plan
- [ ] `cluster-apps-cnpg-default` Kustomization reconciles Ready=True after merge
- [ ] Seer HelmRelease pulls the pinned digest without a slow re-pull

## Notes
Seer v3.2.0 still crashes at startup with `permission denied for schema public` while running migration `AddMediaTypeToUniqueConstraints1772048000333` — unrelated DB-grant issue, tracked separately.