### PR TITLE
fix(ansible): correct OpenWrt connection settings for community.openwrt

### DIFF
--- a/ansible/inventory/group_vars/openwrt/connection.yml
+++ b/ansible/inventory/group_vars/openwrt/connection.yml
@@ -1,0 +1,6 @@
+---
+# OpenWrt ships BusyBox `ash` as `/bin/sh` and has no `/bin/bash` or `sudo`,
+# so override the repo-wide `executable = /bin/bash` and `become = True`
+# defaults from `ansible.cfg` for this group.
+ansible_shell_executable: /bin/sh
+ansible_become: false

--- a/ansible/inventory/host_vars/router.lan.sops.yml
+++ b/ansible/inventory/host_vars/router.lan.sops.yml
@@ -1,19 +1,17 @@
-ansible_host: ENC[AES256_GCM,data:1Vo53StyLZOY+lPN9w==,iv:m6CiLYT+myEsVNI22ourdNfz9xmOdDjc4jKfbWnffE8=,tag:33N6q9nQd6VZXoHvuLurhw==,type:str]
-ansible_user: ENC[AES256_GCM,data:0VOJxg==,iv:ZfKYzkPAcyy42afwTAaxFwPJUev5kFwkXQuk3ydfQug=,tag:XUBjqJf6o91Wz9BIjQHJcg==,type:str]
-ansible_connection: ENC[AES256_GCM,data:Zr0QvjgYNGrI5pLQp3W63L8IuPUBOUpnByGHLsU=,iv:QDKBYSLF9lZq43Zbs6SkCeje8Vb5yRaR6dUIJPacay4=,tag:0U/ixqj4tFtSt/8aF1/bKA==,type:str]
-ansible_network_os: ENC[AES256_GCM,data:meReGoP+TNFSDBTmQARAqTSZXH8yTOYboA==,iv:6r4WY3juKhdf9kkUQFZ5S+xjgAkm4pfXCDiJjvSGE1w=,tag:V4l6BDpyXW3LucE9AesbRg==,type:str]
+ansible_host: ENC[AES256_GCM,data:Zxkh5bWplFQhXNAbJA==,iv:+6UWdQe5cJTvNSjIDLDoHKWsbhjAmZSS9diMtWg/x0A=,tag:+dZUsrk2wwYL6B97A1MbCQ==,type:str]
+ansible_user: ENC[AES256_GCM,data:LHORfg==,iv:O5rhriuhiPThIVFHrhzGeWurbXSN/pdb10hQTTjUQb0=,tag:U0ErNIUUQjyhtjVdiwdTiA==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDT1EwVFBZVUFzSVJITmtZ
-            NFdmeWhDc1VhcG55bzNsdFl1MEMzeHJCblFzCms1QmVRV1Zyd3NjcXRVSE82WnJN
-            aWlWRHBQM1RpaWZxVkZKeFJUcUoxZmsKLS0tIEV2RWVQdEZ1Ym9aNTJjN0I5a2or
-            WWZSNjFJazZydTlySW8va3V4cHVTb0EKb2un29bHd5BzQUm84iRK2NyomOcMsvtX
-            +rywQ+ZbKO9qJVOO2Da8r8BvzLTxsRzAqudXw1Ecjb7CdFd7C4ycDw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwNUROOUhRaGlpUDRWNW9r
+            Wk8xSEtzUGhtTWdHcU5KVy9tK3hrWFRSbTNNCnBSUDEvM0cxOFZzdDI4M1BTSEdN
+            bzRVTTVjWkF5ZDQzZ1V3ZU52K281MkUKLS0tIEloaCtPc1ZSSk94cyt0L096QWRX
+            Q244ZmRGZnVIMUE0YWN6bUFCWHQ4YUEKbNHwJIGavw+wYSGQ8NHt9ztlUd6JoKxA
+            eLkWsPw91Niswt6jQUbDcNsV1JP7+uTYpUaDqZiMK0TcQuUvJXryOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-14T18:14:01Z"
-    mac: ENC[AES256_GCM,data:wGqqI4Fltf12tkYeP+SbS6aWUKA2V63bel05qEpyetczcfDQLuDgNjqBJzmXKIk8mknD9rnFnFa3k5E+JhEjZA/nMIgWGd7nQpEDZCqDgIujQasDqm9P/seZMxRIB0kjeygCF5FvtiChKXuVQQoOeNzD76QelA6rYB3wBoRo4Pc=,iv:58Lt41WLFeaDniwKWf6YBLCDBYLYxWerQkOGMYQY+eA=,tag:P24iuRghEupIRdvMiukPWA==,type:str]
+    lastmodified: "2026-05-14T18:29:55Z"
+    mac: ENC[AES256_GCM,data:a+yJjW6XDSdd6l6mGnZhzpDT1NydEXKM/NAsQIl4QbRVIBHXgzeQ093HH6THXhshp7yBmybcukpyjJ7QvwWd2E6rCkJwuFZ77cyxOHVYXDrqTX4NS9jjMt4tdqdW5d3aJn3kwcZ7onSNdG5+QP3C1fwEInmdI8xhAN+jumGE1bM=,iv:mv2lLK8WPBM0xQqbBxDPuwNY1kn6zjPZCAiod8oXzjI=,tag:mBP0CoaVYxo2EYTbwXStZQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2


### PR DESCRIPTION
## Summary
- Drop bogus `ansible_connection: ansible.netcommon.network_cli` + `ansible_network_os: community.openwrt.openwrt` from `router.lan` host_vars — the `community.openwrt` collection ships no cliconf plugin, so `network_cli` rejected the network_os with *"is not supported"*.
- Override `ansible_shell_executable: /bin/sh` and `ansible_become: false` for the `openwrt` group, since OpenWrt has no `/bin/bash` or `sudo` and the repo-wide `ansible.cfg` defaults to both.

## Test plan
- [x] `ansible-playbook ansible/playbooks/openwrt-router.yml --check -vvv` → ok=9 changed=1 failed=0 unreachable=0
- [x] `drill @192.168.100.1` confirms wildcard `*.home399.thiagoalmeida.xyz → 192.168.100.226` and `.lan` reservations still resolve
- [ ] Real run (no `--check`) reproduces the same single `changed` task on the dnsmasq address override