### PR TITLE
fix(databases): document seer as owner of its database in cnpg-media

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
             severity: critical
           annotations:
             summary: CNPG last backup too old ({{ $labels.pod }})
-            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 26 hours.\n  VALUE = {{ $value | humanizeSeconds }}"
+            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 26 hours.\n  VALUE = {{ $value }}s"
 
         - alert: CNPGWALArchivingFailing
           expr: |
@@ -37,7 +37,7 @@ spec:
             severity: critical
           annotations:
             summary: CNPG WAL archiving lagging ({{ $labels.pod }})
-            description: "No WAL archived in over 1 hour for {{ $labels.namespace }}/{{ $labels.pod }}. Point-in-time recovery is at risk.\n  VALUE = {{ $value | humanizeSeconds }}"
+            description: "No WAL archived in over 1 hour for {{ $labels.namespace }}/{{ $labels.pod }}. Point-in-time recovery is at risk.\n  VALUE = {{ $value }}s"
 
         - alert: CNPGClusterNotHealthy
           expr: |

--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -11,7 +11,7 @@ spec:
   bootstrap:
     initdb:
       database: seer
-      owner: postgres
+      owner: seer
   resources:
     requests:
       cpu: 50m

--- a/kubernetes/apps/media/seer/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seer/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/seerr-team/seerr
-              tag: v3.2.0
+              tag: v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
             env:
               TZ: ${TIMEZONE}
               LOG_LEVEL: "info"


### PR DESCRIPTION
## Summary
Reflects the runtime fix already applied via `ALTER DATABASE seer OWNER TO seer;`. Bootstrap block is a no-op on the existing cluster, but documents intent so a future re-bootstrap is correct.

## Test plan
- [x] `has_schema_privilege('seer','public','CREATE')` returns true on cnpg-media
- [x] Seer HR v3.2.0 upgrade succeeded (release v45)