### PR TITLE
feat(storage): replace MinIO with RustFS (binary swap)

### DIFF
--- a/kubernetes/apps/storage/minio/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/minio/app/helmrelease.yaml
@@ -42,36 +42,42 @@ spec:
         containers:
           app:
             image:
-              repository: quay.io/minio/minio
-              tag: RELEASE.2025-09-07T16-13-09Z
+              repository: docker.io/rustfs/rustfs
+              tag: 1.0.0-beta.3@sha256:378642b05b7dcb4849fb77ebe6aca4ced1c3f66e7e504247df95a5c9018d3358
             env:
               TZ: ${TIMEZONE}
-              MINIO_UPDATE: "off"
-              MINIO_PROMETHEUS_URL: http://prometheus-prometheus.monitoring.svc.cluster.local:9090
-              MINIO_PROMETHEUS_JOB_ID: minio
-              MINIO_BROWSER_REDIRECT_URL: https://minio.${SECRET_DOMAIN}
-              MINIO_SERVER_URL: https://s3.${SECRET_DOMAIN}
-              MINIO_API_CORS_ALLOW_ORIGIN: https://minio.${SECRET_DOMAIN},https://s3.${SECRET_DOMAIN}
-              MINIO_PROMETHEUS_AUTH_TYPE: public
+              RUSTFS_VOLUMES: /data
+              RUSTFS_ADDRESS: ":9000"
+              RUSTFS_CONSOLE_ENABLE: "true"
+              RUSTFS_CONSOLE_ADDRESS: ":9001"
+              RUSTFS_SERVER_DOMAINS: "s3.${SECRET_DOMAIN},minio.${SECRET_DOMAIN}"
             envFrom:
               - secretRef:
                   name: minio-secret
 
-            args: ["server", "/data", "--console-address", ":9001"]
-
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /minio/health/live
+                    path: /health
                     port: 9000
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 10
                   failureThreshold: 6
-              readiness: *probes
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/ready
+                    port: 9000
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
 
             resources:
               requests:
@@ -89,16 +95,6 @@ spec:
             port: 9001
           api:
             port: 9000
-
-    serviceMonitor:
-      app:
-        serviceName: minio
-        endpoints:
-          - port: s3
-            scheme: http
-            path: /minio/v2/metrics/cluster
-            interval: 1m
-            scrapeTimeout: 10s
 
     persistence:
       config:

--- a/kubernetes/apps/storage/minio/app/minio.sops.yaml
+++ b/kubernetes/apps/storage/minio/app/minio.sops.yaml
@@ -6,25 +6,20 @@ metadata:
     namespace: storage
 type: Opaque
 stringData:
-    MINIO_ROOT_USER: ENC[AES256_GCM,data:74mMO/ARhKNKig==,iv:ldRp9V2W4v4F8KNvUA3CHDZzG15Koelp9jIrFuY0dEk=,tag:mfshLY6xh7yszL7PP6VWbQ==,type:str]
-    MINIO_ROOT_PASSWORD: ENC[AES256_GCM,data:CltrLoY6IKgxrGbkdEJH5Xz9OkLkBYLxqSs6JgYRHRE=,iv:+raLcB69KxZ7M+ivSrNSrtcaOkuP2Wa4c09axc5HOoM=,tag:8E/iwuJnA9SPDtJBMdX+HA==,type:str]
+    RUSTFS_ACCESS_KEY: ENC[AES256_GCM,data:tCEY8rNjOEyfqQ==,iv:eZj/KZGF+/VtrydscgYlrxicM0Pq6hXVXnbGfTxPWWI=,tag:cU8AqGpszN2sLUsWwZf+KQ==,type:str]
+    RUSTFS_SECRET_KEY: ENC[AES256_GCM,data:i6WTOwxJJB9hOju5M50I8+EYUHNIiCtgxeHeRu5Hdis=,iv:shImS+lHW0rTYKnHAefFbAFZ2lJITdlxU3XcSIc+2MQ=,tag:jWJ5Ru8MnyRpWGa3NPjJfg==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvYkdjNkt3ZnJWT1FFVHVR
-            SlRDYnBJVFlOLzVkUHBoVWwwWVlzQUlPRzFrCjJYTVFwd2oxWk1OemVkTXBSWTVp
-            eTZBdTdWNS9YNHZzTmFBYVRFdG8yRmsKLS0tIGRGLzlzMTZGZHVYT3BYUnlWRG4v
-            YkRDU0pLcmM1RlBUbjVaYkpBaGJDN0EKwJtF6LBXX40YwxDlile/KYtXG10kRwlv
-            cQgckv6vndaOhC+0WhDyk5t0R1/hHo1+romC6yYLv//Y3ysmh2NdQQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpTzlOOWZHZWNkSXZlZjYx
+            U1JzUnBEOVBZT0FxaXN2SzdIYm1raklFRFdjCmkrb041cTA3Z0F6Smg3bUN6Vi9S
+            dWtKbm94anQwS1dwcW1oUk1TUW9PckUKLS0tIEpLVVkrelhhK3ZLWnJmL3BoSkNB
+            bmJKbTVDQ01CRi9kbjFoSmN3TEY5Vm8Knf4+2cn7heHIa62suffW7W274WNzBp+6
+            vELIIo5GTJ9wCa5aA6g+ebYkQDSukhhCN6iGAh+xXpDw7tbIaDZR2g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-05-21T20:25:16Z"
-    mac: ENC[AES256_GCM,data:Jle7KT5IbvK6q6rgoPaJEk8Hm+mj7S6T6ydAn+cKRnMonsF9qk7sd2xR1udA8rHlGeEl/Qave8eZKmmvqqPvJ9EkpkteItBga0oaKCgN/HdZ2gKIbBIW0x9sLG6SiMbCDM04emu1ztNG4nhQnXrFehRVFbgKSg9e0XRHUs6/Mr8=,iv:1mdirtm51tCx1qQeBxUcKx08IN0ZQGM9MEgnsl8gGpg=,tag:CqKPj88AT1LNlDRRYf7F7A==,type:str]
-    pgp: []
+    lastmodified: "2026-05-14T19:21:25Z"
+    mac: ENC[AES256_GCM,data:0H5v/hdllekfGJXb3JR02NaJO+jMBdzYYVWoXM07rSsV30E8yG++MYVxA8Cd/ItKoEoLDdM3xDGc/THHH6PBGda4ufriuHuSO67Loi+nJAAVQzRZKpNW10AsScNfc+8FTj/yRSOYU1/Ozo0VvqPWhg6J7pxwfJ7+HNhy+4Z3BZ0=,iv:kPI4bUSOdtWja4PR8T2hxPS+tGCivy5+PU4y9K0eca4=,tag:QxKxwCihY3APwt0nhBoLAw==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.10.2


### PR DESCRIPTION
## Summary
- Swap `quay.io/minio/minio` for `docker.io/rustfs/rustfs:1.0.0-beta.3` (pinned by digest) on the same NFS PVC, relying on RustFS's MinIO on-disk-format binary replacement (since `alpha.89`).
- Rename `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` secret keys to `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY`; same values, re-encrypted with the existing age recipient.
- HTTPRoute hosts (`s3.${SECRET_DOMAIN}`, `minio.${SECRET_DOMAIN}`), Service name, ports, namespace, and Flux Kustomization name unchanged — no consumer reconfig needed.
- Probes switched to RustFS-native `/health` and `/health/ready` on 9000.
- ServiceMonitor removed: RustFS 1.0.0-beta.3 has no Prometheus exposition endpoint (upstream issue [#796](https://github.com/rustfs/rustfs/issues/796)); OTel-collector wiring will land in a follow-up.

## Test plan
- [ ] Kopia snapshot of `/data` on `nfs.lan:/volume1/k8s/...` confirmed before merge
- [ ] `flux -n storage get hr minio` reports `Ready: True` on the new revision
- [ ] `kubectl -n storage logs deploy/minio` shows no fatal errors, one-time format-conversion line observed
- [ ] Console at `https://minio.${SECRET_DOMAIN}` accepts `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY`; all existing buckets listed
- [ ] `mc ls homelab/` against `s3.${SECRET_DOMAIN}` lists every bucket
- [ ] CNPG on-demand `Backup` succeeds (multipart PUT path)
- [ ] Loki + Mimir continue returning recent log/metric ranges (read path)
- [ ] Linkwarden + Kopia smoke tests pass