### PR TITLE
feat(media): add recyclarr for TRaSH-guides sync (sonarr + radarr)

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./radarr/ks.yaml
+  - ./recyclarr/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -1,0 +1,127 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: recyclarr
+  namespace: media
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      recyclarr:
+        type: cronjob
+        annotations:
+          reloader.stakater.com/auto: "true"
+        cronjob:
+          schedule: "0 2 * * *"
+          timeZone: ${TIMEZONE}
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+          backoffLimit: 0
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: {type: RuntimeDefault}
+        containers:
+          app:
+            image:
+              repository: ghcr.io/recyclarr/recyclarr
+              tag: 8.6.0@sha256:3c38ceeb54438dd8327e4e65c9b48ba601a6d20fff833342d93c9b0bc4b1930b
+            args: ["sync"]
+            env:
+              TZ: ${TIMEZONE}
+              COMPlus_EnableDiagnostics: "0"
+              RECYCLARR_APP_DATA: /config
+            envFrom:
+              - secretRef:
+                  name: recyclarr-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+    persistence:
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        name: recyclarr-config
+        globalMounts:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    configMaps:
+      config:
+        enabled: true
+        data:
+          recyclarr.yml: |
+            sonarr:
+              main:
+                base_url: http://sonarr.media.svc.cluster.local:8989
+                api_key: !env_var SONARR_API_KEY
+                delete_old_custom_formats: true
+                replace_existing_custom_formats: true
+                quality_definition:
+                  type: series
+                include:
+                  - template: sonarr-quality-definition-series
+                  - template: sonarr-v4-quality-profile-web-1080p
+                  - template: sonarr-v4-custom-formats-web-1080p
+                media_naming:
+                  series: default
+                  season: default
+                  episodes:
+                    rename: true
+                    standard: default
+                    daily: default
+                    anime: default
+            radarr:
+              main:
+                base_url: http://radarr.media.svc.cluster.local:7878
+                api_key: !env_var RADARR_API_KEY
+                delete_old_custom_formats: true
+                replace_existing_custom_formats: true
+                quality_definition:
+                  type: movie
+                include:
+                  - template: radarr-quality-definition-movie
+                  - template: radarr-quality-profile-remux-web-1080p
+                  - template: radarr-custom-formats-remux-web-1080p
+                media_naming:
+                  folder: plex
+                  movie:
+                    rename: true
+                    standard: plex

--- a/kubernetes/apps/media/recyclarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/recyclarr/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/media/recyclarr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/recyclarr/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: recyclarr-secret
+    namespace: media
+type: Opaque
+stringData:
+    SONARR_API_KEY: ENC[AES256_GCM,data:P8R6gYbI+ln8sUKSkm72LUlgZWgZp/dwoBnz/sY5mQs=,iv:nKtDX8HZ9q1V7phZEZKue8DfG2AlsBoxvGusXIvDsAE=,tag:eXE57xfIspRTa6seke3/BQ==,type:str]
+    RADARR_API_KEY: ENC[AES256_GCM,data:f72uFLAxPJyYR2rGvVRMtr/CgWd6JF+ntGzakf2hdsc=,iv:9lFO1xcbQzOCVhREOAO/VyFZCOnc89kttX6OJ+mpbac=,tag:16sFAhgAun4PWKaGKPuMiA==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibUJvb0VQdXk5MTl3d1dy
+            eVJUMFVHU1NiQ0tZMFRaaGNnYUJwMHowNUN3Cm5lMEV1VnM0QzBUL3R2RkcxZFNu
+            Z1pzSnpseHBmenpFbXFOVi9jMGE1MXcKLS0tIFc5QmgwUGZBWXd4OUpGVzdNNWhB
+            dkFoTUNqeGpzSXAzaE5mNTkwZzJ6UEUKMCyuSKjRDHxrQ6F6nMGVek5++2IrTsSK
+            Mq3DkatTr/HhPqknNLrFDvUM/keVIlKhiSk3FLPHIYP/LkTh1yYIfQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-14T19:48:31Z"
+    mac: ENC[AES256_GCM,data:OzZCnrgW420UETPqV3gYHDDjDXfGyVz6iT3AW+0SxvPULhTT5dkDruvXOWepJSQ07kXZdjY4AgKrhSQgmHkW4r+7XhvVm2l9RhQ1Wq+eEPTn4uQEu3Mx/mm3s5FZ4B6eyhucrih9hCd2DtwjQDHTU3rg2r3AuhgBJfcJZLXQL+0=,iv:A2vxdF7KG65o2HlF9rJNDcHq5ZF6xw5C3rvxep83vJ0=,tag:QzitgROjVPT69ho16ha1Yg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: recyclarr
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/media/recyclarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- New CronJob (`app-template` v3.7.3, daily 02:00 in `${TIMEZONE}`) running `recyclarr sync` against the in-cluster Sonarr v4 and Radarr; image `ghcr.io/recyclarr/recyclarr:8.6.0` pinned by digest.
- Sonarr: `sonarr-v4-quality-profile-web-1080p` + matching custom formats; Radarr: `radarr-quality-profile-remux-web-1080p` + matching custom formats. `delete_old_custom_formats`, `replace_existing_custom_formats`, and `media_naming` all enabled.
- Dedicated SOPS `recyclarr-secret` carrying `SONARR_API_KEY` / `RADARR_API_KEY` (extracted from existing arr secrets).

## Test plan
- [ ] Flux reconciles `recyclarr` Kustomization without errors.
- [ ] `kubectl -n media create job --from=cronjob/recyclarr recyclarr-manual-$(date +%s)` succeeds; logs show profiles + custom formats synced for both apps.
- [ ] Sonarr/Radarr UIs show the new TRaSH-named custom formats and quality profile.
- [ ] Media-management naming in Sonarr/Radarr matches TRaSH (heads-up: first library scan after this will trigger a rename).