### PR TITLE
fix(media): mount recyclarr inline configmap by its actual name

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           - path: /config
       config-file:
         type: configMap
-        name: recyclarr-config
+        name: recyclarr
         globalMounts:
           - path: /config/recyclarr.yml
             subPath: recyclarr.yml


### PR DESCRIPTION
## Summary
- Inline `configMaps.config` in app-template v5 renders as a ConfigMap named `recyclarr` (just the release name), not `recyclarr-config`.
- The `persistence.config-file.name` reference was pointing at the wrong name, so the pod failed to mount with `configmap "recyclarr-config" not found` and never started the sync.

## Test plan
- [ ] After merge + flux reconcile, manual run completes: `kubectl -n media create job --from=cronjob/recyclarr recyclarr-manual-$(date +%s)`
- [ ] Logs show successful sync to Sonarr + Radarr (custom formats, profiles).