### PR TITLE
fix(media): rename RECYCLARR_APP_DATA -> RECYCLARR_CONFIG_DIR

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
             env:
               TZ: ${TIMEZONE}
               COMPlus_EnableDiagnostics: "0"
-              RECYCLARR_APP_DATA: /config
+              RECYCLARR_CONFIG_DIR: /config
             envFrom:
               - secretRef:
                   name: recyclarr-secret


### PR DESCRIPTION
## Summary
- Recyclarr 8.x dropped `RECYCLARR_APP_DATA`; the binary now expects `RECYCLARR_CONFIG_DIR`.
- Previous manual run failed with: `Error: RECYCLARR_APP_DATA is no longer supported. ... rename RECYCLARR_APP_DATA to RECYCLARR_CONFIG_DIR`.

## Test plan
- [x] After merge + flux reconcile, `kubectl -n media create job --from=cronjob/recyclarr recyclarr-manual-$(date +%s)` completes with sync output for Sonarr + Radarr.