### PR TITLE
fix(media): recyclarr v8 config + opt out of pod-gateway

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -89,17 +89,16 @@ spec:
         data:
           recyclarr.yml: |
             sonarr:
-              main:
+              sonarr:
                 base_url: http://sonarr.media.svc.cluster.local:8989
                 api_key: !env_var SONARR_API_KEY
                 delete_old_custom_formats: true
-                replace_existing_custom_formats: true
                 quality_definition:
                   type: series
-                include:
-                  - template: sonarr-quality-definition-series
-                  - template: sonarr-v4-quality-profile-web-1080p
-                  - template: sonarr-v4-custom-formats-web-1080p
+                quality_profiles:
+                  - trash_id: 72dae194fc92bf828f32cde7744e51a1
+                    reset_unmatched_scores:
+                      enabled: true
                 media_naming:
                   series: default
                   season: default
@@ -109,19 +108,18 @@ spec:
                     daily: default
                     anime: default
             radarr:
-              main:
+              radarr:
                 base_url: http://radarr.media.svc.cluster.local:7878
                 api_key: !env_var RADARR_API_KEY
                 delete_old_custom_formats: true
-                replace_existing_custom_formats: true
                 quality_definition:
                   type: movie
-                include:
-                  - template: radarr-quality-definition-movie
-                  - template: radarr-quality-profile-remux-web-1080p
-                  - template: radarr-custom-formats-remux-web-1080p
+                quality_profiles:
+                  - trash_id: 9ca12ea80aa55ef916e3751f4b874151
+                    reset_unmatched_scores:
+                      enabled: true
                 media_naming:
-                  folder: plex
+                  folder: default
                   movie:
                     rename: true
-                    standard: plex
+                    standard: standard

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
             env:
               TZ: ${TIMEZONE}
               COMPlus_EnableDiagnostics: "0"
-              RECYCLARR_APP_DATA: /config
+              RECYCLARR_CONFIG_DIR: /config
             envFrom:
               - secretRef:
                   name: recyclarr-secret

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -36,6 +36,8 @@ spec:
           failedJobsHistory: 1
           backoffLimit: 0
         pod:
+          annotations:
+            setGateway: "false"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000


### PR DESCRIPTION
## Summary
- Rewrote `recyclarr.yml` for the v8 config schema: direct `quality_definition` + `quality_profiles` with TRaSH `trash_id`s (Sonarr WEB-1080p, Radarr Remux + WEB 1080p). The v8 templates dropped the includable-templates catalog, so the previous `include: - template:` references failed at startup.
- Renamed instances `main`/`main` → `sonarr`/`radarr` (Recyclarr requires globally-unique instance names).
- Fixed invalid `media_naming` values: Radarr `folder: plex` → `default`, `movie.standard: plex` → `standard`.
- Added pod annotation `setGateway: "false"` so pod-gateway's admission webhook stops injecting the `gateway-sidecar` into the Recyclarr CronJob pods. Without this, the app container exits but the long-running sidecar keeps the Job in "Running" state, blocking `concurrencyPolicy: Forbid` from ever scheduling the next daily fire.

## Test plan
- [x] Patched the live ConfigMap with the new body and ran manual jobs: both Sonarr and Radarr exit 0 with "All custom formats / quality profiles / media naming up to date".
- [ ] After merge + flux reconcile, the next manual job (`kubectl -n media create job --from=cronjob/recyclarr recyclarr-manual-$(date +%s)`) terminates cleanly (no stuck sidecar) and the Job moves to Complete.