### PR TITLE
feat(monitoring): wire Envoy / Overview dashboard for Cilium Gateway

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
@@ -7,5 +7,15 @@ configMapGenerator:
   - name: cilium-helm-values
     files:
       - values.yaml=./helm-values.yaml
+  - name: cilium-envoy-dashboard
+    files:
+      - envoy-overview.json=https://grafana.com/api/dashboards/24459/revisions/3/download
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana_folder: Cilium
+        kustomize.toolkit.fluxcd.io/substitute: disabled
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
## Summary
- Add community Envoy / Overview dashboard ([grafana.com 24459](https://grafana.com/grafana/dashboards/24459-envoy-overview/), rev 3, by adinhodovic) referenced inline via the cilium `configMapGenerator` — no JSON checked into the repo, matches the cert-manager pattern.
- Chart-shipped dashboards in #2591 cover cilium-agent and cilium-operator only; this one populates from `envoy_*` metrics exposed by the cilium-envoy ServiceMonitor and surfaces Gateway API traffic (downstream listeners, upstream clusters, latency, status codes, TLS cert expiry).

## Test plan
- [ ] Flux reconciles `cilium` Kustomization without errors
- [ ] `cilium-envoy-dashboard` ConfigMap appears in `kube-system` with `grafana_dashboard=1`
- [ ] "Envoy / Overview" shows up in Grafana under the **Cilium** folder
- [ ] Panels populate when traffic flows through a Gateway-API-backed HTTPRoute