### PR TITLE
feat: split-horizon DNS for public-domain hostnames on the LAN

### DIFF
--- a/ansible/inventory/group_vars/openwrt/network.yml
+++ b/ansible/inventory/group_vars/openwrt/network.yml
@@ -1,0 +1,5 @@
+---
+# Internal Cilium gateway IP (mirrors GATEWAY_INTERNAL_ADDR in
+# kubernetes/flux/vars/cluster-settings.yaml). LAN dnsmasq points homelab
+# hostnames here so traffic stays local.
+internal_gateway_ip: 192.168.100.226

--- a/ansible/inventory/group_vars/openwrt/vars.sops.yml
+++ b/ansible/inventory/group_vars/openwrt/vars.sops.yml
@@ -1,18 +1,22 @@
-#ENC[AES256_GCM,data:3DujcRiDCXA8SBMH86WxV+BSVndhp2nlg6ZE7JzpsmDLgFoNBFAnibSsXtCWLqJH81whS+8rkbVlnFCwPUp2TVvqykVvj+ZUgQQ/zCCswg==,iv:T3Ug/r4Pk+3nRduyhhyX5Qvotk9SmfYfhUnNwDsuwSo=,tag:+4Y63JthuP3Abqm/pS+hfA==,type:comment]
-#ENC[AES256_GCM,data:Qb8dB4pCc7qrQ83ab8Z3M9MJc6K8i3i7TRHnt8peEpjJDsnQmR4IepmyFY+GmiNpXEMctyWSalnj3VyNG1y6,iv:snOwR6UYcmc0Q/ueAboIx8BmR2y+xSGbUu1cCs1ocZA=,tag:govbUGO+GyqyOn/sVD8gnw==,type:comment]
-secret_domain: ENC[AES256_GCM,data:SQN9TDu5gydoyBGe2BVPfIrSORBc5WLkBA==,iv:+h+pEenUY+abzsWgtOiJcqAbHvi47rUqJIdNDSiS6Fg=,tag:LCG3INEX8TAPzowO2WY2dw==,type:str]
+#ENC[AES256_GCM,data:pq2At+LTcek7ZcWCjsElaxMYcrhS+1OhBJ24tmjbRC8HEpsQlysQTdRtvWbIGUMBOz8ku7mzXKVZDjYII196solwKQQTC6LSoE6kjG8GMw==,iv:iMXlIM+IdPqvEI9wML0hr7Cg90BlomZMsmc8Ek2gI4w=,tag:KsmIVQg3H17Dbta4s0Pi+Q==,type:comment]
+#ENC[AES256_GCM,data:/0NoL+AmYn1yZaI+ijJJroZNKLxmbNWOGyQ4QjcJ93y99FLMz4+VQlN3CZIplFuS/Saixsqhr+wp4iGqOFRb,iv:ogj5HylFYOnPxvvhybWHidC9jzAX7vONbgL/gWq/lcw=,tag:C/6E55FO7kBjBWdZX6yDKQ==,type:comment]
+secret_domain: ENC[AES256_GCM,data:7zm/YLvCnqtd/Uef+eT6ZuAKKUqb+2ftEA==,iv:JsuKZQtBkNQhrBIn7q178XTwUUEToKOaHp21h2/WLtg=,tag:aaMNco52fYxxjNSpXfqasg==,type:str]
+#ENC[AES256_GCM,data:3RQlIQWQq0zInlUjbUJbXQZRl9hCBSGd/wUris4TGhjp7G7qUdd07l7ExBidyqM8ThPpDsj6G9m51pG+GSXfApFS/l39EmTb,iv:6j93Zd7h5oZ0p8lkPcUwTKaqjy2+UjSVjDQoNsSfXQ0=,tag:MLHLqgmGu10Ni6gy3fZkSA==,type:comment]
+#ENC[AES256_GCM,data:NkUNLRaZ3jKICk2m1OkuHWc099tQg4xOhqN+It3RejAHyIWSN7OQrUMoaWJp7h21A3JPa8bgDZdBwKdbKfpEG3I=,iv:bPYYnrCH0kt4F8Fsi54Wh23WbsZ9zshof0woOv5ZZDM=,tag:aipqE7u9ugJ9rTKAntwkLQ==,type:comment]
+#ENC[AES256_GCM,data:HpHr6quJl9I8odbtIxTD8LZzivl+Vpz7aNGkisOe8K/theCOsf72dPV6loBYf1JYvxtTc0u9EFspG+OGEYs8,iv:RGqznmwx3dMWz0CtBCCMhokX/T6gkgvW51kQTc1qp64=,tag:18/WnbM8sQI7Vw3WBZDmoQ==,type:comment]
+public_domain: ENC[AES256_GCM,data:6nCOwrXVCzHxD2KAFssYd9c=,iv:U68mDq4HcuhSi231ifdm7vYED4Jwhg/7cXp0q5J4DQY=,tag:NAnDnqVwxhBLAG1OcEMZGw==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFaGRheDRiVVNGNHI2Yk1U
-            b1pRTXk2TTFoTmRJbGwxRDJOZml4K1BUMVc0ClI1d1JZL3VDa1Fxb0NUcFhhWk4r
-            bGNjMWtxelB1ekJORXkwVldKeUNrek0KLS0tIHJpcWIwaGtkN1ovdnVTbldoQjN5
-            VnJrY1o2K1V5bGt2djV0ZHQ0WmFVSjQK3CiTRbDGY9q080bx1P4vkV/HRl3L1Srp
-            yhZhqbXTGAD6m087o849NTQSLlA5qEal61L9L9dF8ZPHCGWEddx5ww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMeDBXOUs3T0MzbkJCY0VT
+            R21JTTVMa3dMOFp4SlQxRjkrQzBhMlU2Tm5vCmVLbUhuVW5rNEhleVBGMVRYeXd6
+            blRnakt0V2lBOTQzMzM3Y1l3NmQ0K2sKLS0tIFJZWDR6elVDdHRqZGh2Uko0K1RC
+            L0FtMWJnVUwyQ3pFWiswMjBuVHZKVE0KZPNnH3tblRUSh0kpqkkWfJRBVV8uTYb7
+            FK9r4ZTYVklSzYWJCgpXoAEu9uFYmyKvmsodtOCogRVaZ1CsIw9N/Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-14T18:11:36Z"
-    mac: ENC[AES256_GCM,data:lJdLou71xmA9CilmTeU7wVcneTPtrI4peLCGargmYkKSzb8SseEckiR5iNAFvxK2z8/J1uFxrcFefZjEE7dpf/XytVzTZVe9t86fX4U9JOKvc+8fBwbiqz8XqLDI/CscdKKyY5Yw+MxTpAmQrLrYhnZPr47Yq92F0HXTD/q3Y5Y=,iv:z2F+EjLWVRrhD1SktNVqYhgEmVSjAmdQ16iNOvOK0+E=,tag:C7yZNX7yLR95C/nFNU8kSQ==,type:str]
+    lastmodified: "2026-05-16T12:11:58Z"
+    mac: ENC[AES256_GCM,data:SKPAU5NOK2pUhypKMRjcL17Oljc5IP+bLhgjWgPfmpt5t7NMTYet4SzOjWCktuq7hTasiHzviURA1GiJcYko5jUT82SEZQ1Z/z0z10N5b/4oWre6FmcZGxYqUGPzI9ZcGA5+o0cZjkUW0ep8ron9nM7kpYapT8VImXGyqiANsMk=,iv:jMXMPSUW250RTcRkd+uNHKlqcLrrRUp56fZMO8ShQGc=,tag:hYIovU0JJBkvz8oQplzAvA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -34,11 +34,19 @@
     #   - host[9]  kube-vip-invalid (no name)
     #   - domain   mqtt.lan -> virtual hostname, no lease
     #   - domain   console.gl-inet.com -> router self (vendor vanity)
+    # `internal_gateway_ip` is defined in
+    # ansible/inventory/group_vars/openwrt/network.yml.
     dns_address_overrides:
-      # Internal Cilium gateway (GATEWAY_INTERNAL_ADDR in
-      # kubernetes/flux/vars/cluster-settings.yaml) — the only LAN-routable
-      # cluster entrypoint. Wildcard covers every LAN-only homelab subdomain.
-      # `secret_domain` lives in inventory/group_vars/openwrt/vars.sops.yml.
-      - { domain: "{{ secret_domain }}", ip: 192.168.100.226 }
+      - { domain: "{{ secret_domain }}", ip: "{{ internal_gateway_ip }}" }
+    # Public-domain hostnames also served via the LAN gateway. Each entry is
+    # expanded by the role into `address=/<sub>.<public_domain>/<gateway>` so
+    # LAN clients skip the Cloudflare Tunnel hairpin. flux-webhook is excluded
+    # on purpose — only GitHub calls it.
+    public_lan_subdomains:
+      - analytics
+      - media
+      - photos
+      - portfolio
+      - share
   roles:
     - role: openwrt-router

--- a/ansible/roles/openwrt-router/tasks/dns-address-overrides.yml
+++ b/ansible/roles/openwrt-router/tasks/dns-address-overrides.yml
@@ -9,12 +9,16 @@
   ansible.builtin.set_fact:
     dnsmasq_address_directives: >-
       {{
-        dns_address_overrides
-        | map(attribute='domain')
-        | zip(dns_address_overrides | map(attribute='ip'))
-        | map('join', '/')
-        | map('regex_replace', '^', '/')
-        | list
+        (dns_address_overrides | default([])
+          | map(attribute='domain')
+          | zip(dns_address_overrides | default([]) | map(attribute='ip'))
+          | map('join', '/')
+          | map('regex_replace', '^', '/')
+          | list)
+        +
+        (public_lan_subdomains | default([])
+          | map('regex_replace', '^(.*)$', '/\1.' ~ public_domain ~ '/' ~ internal_gateway_ip)
+          | list)
       }}
 
 - name: DNS | Set dnsmasq address overrides

--- a/kubernetes/apps/default/immich/app/server/httproute.yaml
+++ b/kubernetes/apps/default/immich/app/server/httproute.yaml
@@ -31,6 +31,9 @@ spec:
     - name: external
       namespace: networking
       sectionName: https
+    - name: internal
+      namespace: networking
+      sectionName: https
   hostnames:
     - "photos.${PUBLIC_DOMAIN}"
   rules:

--- a/kubernetes/apps/default/photoprism/app/httproute.yaml
+++ b/kubernetes/apps/default/photoprism/app/httproute.yaml
@@ -31,6 +31,9 @@ spec:
     - name: external
       namespace: networking
       sectionName: https
+    - name: internal
+      namespace: networking
+      sectionName: https
   hostnames:
     - "portfolio.${PUBLIC_DOMAIN}"
   rules:

--- a/kubernetes/apps/default/pingvin-share/app/httproute.yaml
+++ b/kubernetes/apps/default/pingvin-share/app/httproute.yaml
@@ -11,6 +11,9 @@ spec:
     - name: external
       namespace: networking
       sectionName: https
+    - name: internal
+      namespace: networking
+      sectionName: https
   hostnames:
     - "share.${PUBLIC_DOMAIN}"
   rules:

--- a/kubernetes/apps/default/umami/app/httproute.yaml
+++ b/kubernetes/apps/default/umami/app/httproute.yaml
@@ -11,6 +11,9 @@ spec:
     - name: external
       namespace: networking
       sectionName: https
+    - name: internal
+      namespace: networking
+      sectionName: https
   hostnames:
     - "analytics.${PUBLIC_DOMAIN}"
   rules:

--- a/kubernetes/apps/media/jellyfin/app/httproute.yaml
+++ b/kubernetes/apps/media/jellyfin/app/httproute.yaml
@@ -36,6 +36,9 @@ spec:
     - name: external
       namespace: networking
       sectionName: https
+    - name: internal
+      namespace: networking
+      sectionName: https
   hostnames:
     - "media.${PUBLIC_DOMAIN}"
   rules:


### PR DESCRIPTION
## Summary
- OpenWrt dnsmasq now resolves `analytics|media|photos|portfolio|share.${PUBLIC_DOMAIN}` to the internal Cilium gateway (`192.168.100.226`), keeping LAN traffic local instead of hairpinning through the Cloudflare Tunnel. `flux-webhook.${PUBLIC_DOMAIN}` is intentionally excluded.
- Each corresponding public HTTPRoute (umami, pingvin-share, immich-public, photoprism-public, jellyfin-public) now also attaches to the `internal` Gateway so the LAN-resolved hostname is actually served. external-dns is gated by `--gateway-name=external`, so Cloudflare records are unaffected.

## Test plan
- [ ] On a LAN client: `dig +short @192.168.100.1 photos.thiagoalmeida.xyz` → `192.168.100.226`
- [ ] `curl -kI https://photos.thiagoalmeida.xyz` from LAN → served by Immich (not the error-pages catch-all)
- [ ] Same for `analytics`, `portfolio`, `share`, `media`
- [ ] `dig flux-webhook.thiagoalmeida.xyz` still returns Cloudflare public IPs
- [ ] Cloudflare DNS unchanged (external-dns reconciles cleanly)