### PR TITLE
fix(default): point pingvin-share HTTPRoute at the actual pingvin Service

### DIFF
--- a/kubernetes/apps/default/pingvin-share/app/httproute.yaml
+++ b/kubernetes/apps/default/pingvin-share/app/httproute.yaml
@@ -18,5 +18,5 @@ spec:
     - "share.${PUBLIC_DOMAIN}"
   rules:
     - backendRefs:
-        - name: pingvin-share
+        - name: pingvin
           port: 3000


### PR DESCRIPTION
## Summary
- The `pingvin-share` HTTPRoute referenced backend Service `pingvin-share`, which does not exist — the app-template HelmRelease creates a Service named `pingvin` (from `metadata.name: &app pingvin` in `kubernetes/apps/default/pingvin-share/app/helmrelease.yaml`).
- Result: `ResolvedRefs=False` on both `external` and `internal` parents; `share.${PUBLIC_DOMAIN}` was 5xx-ing for any caller. Fix swaps the backendRef name to `pingvin:3000`.

## Test plan
- [x] `kubectl -n default get httproute pingvin-share -o json | jq '.status.parents[].conditions[] | select(.type=="ResolvedRefs")'` → `status: "True"` on both parents
- [x] LAN: `curl -kI --resolve share.thiagoalmeida.xyz:443:192.168.100.226 https://share.thiagoalmeida.xyz/` → pingvin response (not error-pages)
- [x] Public: `curl -I https://share.thiagoalmeida.xyz/` → pingvin response via Cloudflare Tunnel