### PR TITLE
fix(seer): rotate db password

### DIFF
--- a/kubernetes/apps/media/seer/app/seer.sops.yaml
+++ b/kubernetes/apps/media/seer/app/seer.sops.yaml
@@ -6,24 +6,24 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    DB_TYPE: ENC[AES256_GCM,data:ALwpN2sgsiE=,iv:2ZNnFxBkbUJemvd+MqngZj5A2k+2hF7hP9kYkHqFNcU=,tag:7ZXrbGypew20Nc17ffXK1g==,type:str]
-    DB_HOST: ENC[AES256_GCM,data:RakjwR1GpJP7FpdOmj9UQ/0DtC9TZTO6OjKVg+cGStixtAi2BoWlcT4=,iv:liEb1itt/prLqjPcMUuu49tLJ73Otgra5aCEP6Zxgec=,tag:alZ4cD0MWG2Ms8b+RJlF6w==,type:str]
-    DB_PORT: ENC[AES256_GCM,data:egG0eg==,iv:PW2GcyA2BCQZiu8FKIXGe8J69WA8sMin7Y/ANw9nFyA=,tag:GfgJKUr1QTc73hcYDF1k1w==,type:str]
-    DB_NAME: ENC[AES256_GCM,data:Ga9JBg==,iv:2BwCMropZIAUgeTZh1kDXPcp04BXiM1IaO8ky9xltsU=,tag:ofb//UW2F6P/4yRQdxunjA==,type:str]
-    DB_USER: ENC[AES256_GCM,data:257PLg==,iv:w6qEJbzRtwSHpx1xQIe28OdsJopd4dwfNgXoLLuZ2Bo=,tag:EmasYABBYstXg3c7J+0Fvw==,type:str]
-    DB_PASS: ENC[AES256_GCM,data:XfhrYQ3qtGTvER4g9JR+l0Ekpslym8LAx61whtSgTL0eoVZL6qNNATPHgH823ETfh7k39GJqCnG3K7glYOXI8w==,iv:aOMQKLnGdV4HrKL9YxNsqUBmS/FVvyNLeM6H7udh868=,tag:6DP7afBW641JRTLvQVcUng==,type:str]
+    DB_TYPE: ENC[AES256_GCM,data:hp+wYU7ekRI=,iv:L+9GzkU0gDlXaDkbiOk1ZLx/5RSflwwAZT2ZPY5KLWM=,tag:XGIx/AOHfYX79bn25nUFUQ==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:KBMtTMM58HlpgASKFXWUMDi16lP6jWUHZ2uUMCKkV7nxkTd4yWeZciQ=,iv:DNEdeOVbKU3jMRKfaCRPbPTAvcnz4Tub9WffEmSRIQc=,tag:G8rbEhO68EkIDUHAcJRp1Q==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:h9OxKQ==,iv:JGyh6TeOHBiGddu4YB00gFWpT5CBD8h2fs77c0IadaA=,tag:R8PFGdgwvvKse4t+l4RjXg==,type:str]
+    DB_NAME: ENC[AES256_GCM,data:h7GoVg==,iv:5IGt4oVzdyN6C6LxpdaQay70TTya3GIV2RK5z8Q8Jds=,tag:wg3CphELE22XDv0MRlvahw==,type:str]
+    DB_USER: ENC[AES256_GCM,data:7uVS4A==,iv:i9CCiWQB2XrqFxZUdACD0t0sNq9IiBQh1/4zoXViDoU=,tag:xJSFCZCpy0l/GNkqLEbKDQ==,type:str]
+    DB_PASS: ENC[AES256_GCM,data:GWNkbmqKAnHw5kMVuSzpgsPJoSNM0J1G/9RuZDOHfxk=,iv:UhhC3e+3qXSzPJO6uUqAKNgT6aChc8GiZL7RoscLjAs=,tag:1nyjbO2ygWiPjyiJXiPQeA==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaNWFmQitlSEtlQVllQXJH
-            ZmZITVN6MlRxaXNHY0l2eGFETVl3VDI3VWlBCmpZTEM4bi90RkxCdmVNempleEhP
-            YnUzSk90TVZSNndtWC9pZHNQMVBsS3cKLS0tIFBtZlJBQWJKa2pLS0pPZ0N2SVBl
-            OUY3aDFaeFlsRjZRajU2U2ozWTdtMEkKbb2vpyvAqIgvIgA8D3sIf1uLxJjObfgx
-            EX9yOTt6XLs1xBMQGj7F6/kJ296JAacr9PW/MZo/dTQ5dqsRwz/OuA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyQXN0b2JicTJ4RlozbGQy
+            SHE0ZThNYWZtQW9hZE5rR0RzeUVDeVEwbzFBCmwrSkVNMXh6SUN2YllPRXNBV3pp
+            amN2ajJ2THNRM3FmbW04UkQxKzJYT2MKLS0tIFFxKzZCNzR1L3M1clltK3JncG16
+            bWJvbTZNTHJFcHZqaFhHUVhNMTRGOHMK71ogvCubhb7npJyHcmJ8V5a9As9dwigZ
+            paKHljj48wTX/BKLTS3tXpFUgs9XGeagYsxpFJAUB5RZ1HudtSBZrQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-15T13:31:11Z"
-    mac: ENC[AES256_GCM,data:7cbHWabrcjMeorT7dW+wxPbqqoqEgrpI7WtRD7pjDFFOagZaFM5Vo+a+IkbcpwCL18P9iCeL+c91+aDAYqYvyUY7Z6icSMqI7egEL/XlRIB+Osx+TTLggwPcocdwFkV7y2off0bHoGncKx1DCLN53+XH6C4fxbOtJ9wwA4E4PG8=,iv:IdGSPE+IzXPfTwSFFUc+GrOSUdl752pIsNps/g3KQgc=,tag:0CGBStj/W84a9lu5TzfInQ==,type:str]
+    lastmodified: "2026-05-16T13:30:41Z"
+    mac: ENC[AES256_GCM,data:yZrIbJFWjS89gnG84loezrNqOukRXVRwgvgszLNs/Xq0Nvj6CUzKybxAyf4CYsCSSVRKdokGZEsRDFTQuKNiel17u4m3TZe5O/7mJx+riiC3+J3mJ75jZ4Pd8OUWVQPx4UqE8/OQvyNatJ6+1GXvlmeJtGtpKPtYqhQ4p1A8F9o=,iv:TqHAExixeCyL9EnT0e6HEm4FqVkrmQ/NuwL5VtOnHWc=,tag:LeyF9VcNzjGcjTNcg/qkxg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary
- Rotates the `seer` PG role password and updates `seer-secret` to match `cnpg-media-app`.

## Test plan
- [x] seer pod authenticates and reports "Server ready on port 80"
- [ ] Flux Kustomization `seer` resumed after merge: `flux -n flux-system resume kustomization seer`