### PR TITLE
fix(homepage): enable HTTPRoute discovery with gateway: true

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -159,6 +159,7 @@ spec:
                   showLabel: true
           kubernetes.yaml: |
             mode: cluster
+            gateway: true
           docker.yaml: ""
           custom.css: ""
           custom.js: ""


### PR DESCRIPTION
Without this flag homepage only scans Ingress / Traefik IngressRoute and ignores every gethomepage.dev/* annotation we added on HTTPRoutes in #2638, leaving the dashboard empty after the hajimari migration.