### PR TITLE
feat(storage): deploy RustFS

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./kopia/ks.yaml
   - ./longhorn/ks.yaml
   - ./minio/ks.yaml
+  - ./rustfs/ks.yaml
   - ./snapshot-controller/ks.yaml

--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rustfs
+  namespace: storage
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      rustfs:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: {type: RuntimeDefault}
+        containers:
+          app:
+            image:
+              repository: docker.io/rustfs/rustfs
+              tag: 1.0.0-beta.3@sha256:378642b05b7dcb4849fb77ebe6aca4ced1c3f66e7e504247df95a5c9018d3358
+            env:
+              TZ: "${TIMEZONE:=Etc/UTC}"
+              RUSTFS_VOLUMES: /data
+              RUSTFS_ADDRESS: ":9000"
+              RUSTFS_CONSOLE_ENABLE: "true"
+              RUSTFS_CONSOLE_ADDRESS: ":9001"
+            envFrom:
+              - secretRef:
+                  name: rustfs-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 9000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/ready
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        controller: *app
+        ports:
+          api:
+            port: *port
+          http:
+            port: 9001
+    route:
+      console:
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["rustfs.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+      s3:
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["s3-rustfs.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: api
+    persistence:
+      data:
+        accessMode: ReadWriteOnce
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-provision
+        size: 20Gi
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/storage/rustfs/app/kustomization.yaml
+++ b/kubernetes/apps/storage/rustfs/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rustfs.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/storage/rustfs/app/rustfs.sops.yaml
+++ b/kubernetes/apps/storage/rustfs/app/rustfs.sops.yaml
@@ -1,0 +1,25 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: rustfs-secret
+    namespace: storage
+type: Opaque
+stringData:
+    RUSTFS_ACCESS_KEY: ENC[AES256_GCM,data:U3J9bnWBD8jdwno/xxqHbv9TjR1CWStM,iv:Gjq4wKL24GnxNKutG3IitBJzOenNQEUbMaX4TSRiBqA=,tag:9hzx61KXMswFAz6MmVEdyg==,type:str]
+    RUSTFS_SECRET_KEY: ENC[AES256_GCM,data:VDl2fN+V7MdvziE+VBTSFxtQ1GjD6Bo6Og4ZcbCcgUBiDXOKeB6skg==,iv:l5QTtIt156E/B9DHuO/15kuBb7ypnzlYk9AITI/VA/g=,tag:DXaFkdnOp8tXo9/OhPMgHw==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJSDA5MkJ5V2htcEJROHJn
+            WCt5VnZLUnZscWZhNnUvckpDVnJLRlFBV1hRCngzS1BINkVDRzZ0c1Mybm9VcUhJ
+            YWw0NU1TbURjUm9XZkI5eVB1MHovc28KLS0tIHJxeHRIWkw5MU5XWFZsQWxpT2tB
+            YmdlVXZBWUtoT1NjNHpXck1HZitaSFkKkWyqNtFNuvlkCwKGy0LCIzqlG2hEon98
+            8t++uU5JWfNYiofyvIJsTZC2wiVgMSG90kA7/kXXJxkCxtja7Qi+cQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-15T06:20:02Z"
+    mac: ENC[AES256_GCM,data:5mkRf25IpditnzE6oKWpVteYnI/mtnGrKRHwztlvfBCIq5eqw2Ry6GSNbd2KfbGjXQjyzcR8Db7AZloAHk/TQpS26Y2AC8nyMaf+g5iGymrCVQER3m72U9XtdwkkmBnZYPhLPMqmohqXoRvshFqj9/n43+GHBludtvE+KQsfvx8=,iv:6spbEedvqPQpcowI8VA4A949MTScRdDCo6o5VDCGRwg=,tag:o0TDAVBx47nATStt2jVPEw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/storage/rustfs/ks.yaml
+++ b/kubernetes/apps/storage/rustfs/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rustfs
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/storage/rustfs/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- bjw-s app-template v5 HelmRelease at `kubernetes/apps/storage/rustfs/`, fresh 20Gi PVC on `nfs-provision`
- Console + S3 HTTPRoutes on `internal` gateway only: `rustfs.${SECRET_DOMAIN}`, `s3-rustfs.${SECRET_DOMAIN}`
- Image pinned to `docker.io/rustfs/rustfs:1.0.0-beta.3@sha256:378642b05b7dcb4849fb77ebe6aca4ced1c3f66e7e504247df95a5c9018d3358` (multi-arch)
- Bench v2 vs MinIO/VersityGW: RustFS wins 4 KiB PUT/GET (+50-60%) and 64 MiB multipart PUT (+70%)

## Test plan
- [ ] Flux reconciles `storage/rustfs` HR Ready=True
- [ ] `kubectl -n storage logs deploy/rustfs` shows clean startup (`/health` 200)
- [ ] Console at `https://rustfs.${SECRET_DOMAIN}` accepts root creds
- [ ] `mc ls https://s3-rustfs.${SECRET_DOMAIN}` lists 4 buckets (cnpg-backups, linkwarden, mimir, terraform-state)