### PR TITLE
refactor(jellyfin): offload subtitles + People imgs to NFS

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -172,6 +172,15 @@ spec:
         path: "${NFS_MEDIA}/intros"
         globalMounts:
           - path: "/media/intros"
+      jellyfin-cache:
+        type: nfs
+        server: "${NFS_SERVER}"
+        path: "${NFS_MEDIA}/.cache/jellyfin"
+        globalMounts:
+          - path: "/config/data/subtitles"
+            subPath: subtitles
+          - path: "/config/metadata/People"
+            subPath: people
       transcode:
         enabled: true
         type: emptyDir


### PR DESCRIPTION
## Summary
- Adds two NFS bind-mounts to the Jellyfin helmrelease, at `/config/data/subtitles` and `/config/metadata/People`
- Backs `${NFS_MEDIA}/.cache/jellyfin/{subtitles,people}` on `nfs.lan`
- Reclaims ~14 G of regenerable cache × 3 Longhorn replicas = ~42 G

## Test plan
**Migration must happen before merge** — the bind-mounts will hide the existing cache otherwise. Operator runs (Job manifest kept local in \`hacks/\`, not committed):

- [ ] On NFS: \`mkdir -p /volume1/Media/.cache/jellyfin/{subtitles,people} && chown -R 1000:1000 /volume1/Media/.cache/jellyfin\`
- [ ] \`flux suspend hr -n media jellyfin\`
- [ ] \`kubectl -n media scale deploy jellyfin --replicas=0\` (wait for terminate)
- [ ] \`kubectl -n media apply -f hacks/jellyfin-cache-offload-job.yaml\`
- [ ] \`kubectl -n media wait --for=condition=complete job/jellyfin-cache-offload --timeout=30m\` + check logs
- [ ] \`kubectl -n media delete job jellyfin-cache-offload\`
- [ ] Merge this PR
- [ ] \`flux resume hr -n media jellyfin\`
- [ ] Verify: \`kubectl -n media exec deploy/jellyfin -c main -- df -h /config /config/data/subtitles /config/metadata/People\`
- [ ] Play a movie with embedded subs; open a cast page