### PR TITLE
fix(databases): shrink cnpg-media pvc to 5Gi

### DIFF
--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -19,7 +19,7 @@ spec:
     limits:
       memory: 512Mi
   storage:
-    size: 10Gi
+    size: 5Gi
     storageClass: longhorn
   backup:
     retentionPolicy: "7d"


### PR DESCRIPTION
## Summary
- Reduce `cnpg-media` PVC from 10Gi to 5Gi after live pg_basebackup migration (data is ~700 MiB).