### PR TITLE
chore(terraform): track local-s3-buckets module

### DIFF
--- a/terraform/local-s3-buckets/.gitignore
+++ b/terraform/local-s3-buckets/.gitignore
@@ -1,0 +1,42 @@
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform
+
+state.config*

--- a/terraform/local-s3-buckets/.terraform.lock.hcl
+++ b/terraform/local-s3-buckets/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/aminueza/minio" {
+  version     = "1.15.3"
+  constraints = "~> 1.15.0"
+  hashes = [
+    "h1:hjUTyJpjp3+MVkBiZgTThzpZmUa0l39aFnTCdKJUCp4=",
+    "zh:290c76ac4e10819c75018b9ea9dc9038324de9b2c06b855f17dfcaa6dc6cc94e",
+    "zh:3f9575d33e4923151c6d806c6153693b79e409120a1dc3d463dc309e8c8b406c",
+    "zh:49cd9cf306da43b4884f7f116fb1089e5d86de644d45bcce194aced6f3ab07c7",
+    "zh:52e4862b88219e7cae5d31e3d9cea6a7dfc18112237932482ef722f39c272309",
+    "zh:58e6dabb089bb32999fab95c01d6dfaa332c746fcbac4c79dd0e414639130969",
+    "zh:71fa1c8806a43b1daae10d2b9e90af321575df538dfec06d36f947381cb422ad",
+    "zh:7fb8beeb48567f1afe91a8080ab767fc75b63fb72989b2306c5327c37f373eae",
+    "zh:843cd2af5aabeed5cb3d8c3932910a03be08de8bef44c20e958608436b29ec1f",
+    "zh:9005a5ae9ce9572df75ff3d786111a8d6d6adab9392b6215ceb0c2878a99ac59",
+    "zh:973dbca012b10b37444650e31b854be1e74d8ce13c61a4d9be0e614079458207",
+    "zh:9c27536f3fe85b7096942a1cdd3178eb3c25d9a56c6e9c34979b7cb3a1437237",
+    "zh:e16fea701bb3f63d8c6338350e552b7daf0b056b21f73df320a742136712dbfc",
+  ]
+}

--- a/terraform/local-s3-buckets/cnpg.tf
+++ b/terraform/local-s3-buckets/cnpg.tf
@@ -1,0 +1,50 @@
+# Bucket
+resource "minio_s3_bucket" "cnpg_backups" {
+  bucket = "cnpg-backups"
+  acl    = "private"
+}
+
+# Service account with scoped policy
+resource "minio_iam_user" "cnpg" {
+  name = "cnpg-backup"
+}
+
+resource "minio_iam_policy" "cnpg_backup" {
+  name = "cnpg-backup-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+      ]
+      Resource = [
+        "arn:aws:s3:::cnpg-backups",
+        "arn:aws:s3:::cnpg-backups/*",
+      ]
+    }]
+  })
+}
+
+resource "minio_iam_user_policy_attachment" "cnpg" {
+  user_name   = minio_iam_user.cnpg.name
+  policy_name = minio_iam_policy.cnpg_backup.name
+}
+
+# Output the access key for use in SOPS secrets
+resource "minio_iam_service_account" "cnpg" {
+  target_user = minio_iam_user.cnpg.name
+}
+
+output "cnpg_access_key" {
+  value = minio_iam_service_account.cnpg.access_key
+}
+
+output "cnpg_secret_key" {
+  value     = minio_iam_service_account.cnpg.secret_key
+  sensitive = true
+}

--- a/terraform/local-s3-buckets/generate-state-config.sh
+++ b/terraform/local-s3-buckets/generate-state-config.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Generate state.config for the Terraform S3 backend by fetching the
+# MinIO Terraform service-account credentials from Bitwarden via rbw.
+# The Bitwarden item stores the value pre-formatted as `access_key = "..."`
+# and `secret_key = "..."`, so we just write it out verbatim.
+#
+# Usage:
+#   ./generate-state-config.sh
+#
+# Run before `terraform init -backend-config=state.config`.
+set -euo pipefail
+
+ITEM="${RBW_ITEM:-minio-tf-creds}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+command -v rbw >/dev/null || { echo "error: rbw not installed" >&2; exit 1; }
+
+rbw get "$ITEM" > "$HERE/state.config"
+chmod 600 "$HERE/state.config"
+echo "Wrote $HERE/state.config"

--- a/terraform/local-s3-buckets/linkwarden.tf
+++ b/terraform/local-s3-buckets/linkwarden.tf
@@ -1,0 +1,61 @@
+# Bucket
+resource "minio_s3_bucket" "linkwarden" {
+  bucket = "linkwarden"
+  acl    = "private"
+}
+
+# Service account with scoped policy
+resource "minio_iam_user" "linkwarden" {
+  name = "linkwarden"
+}
+
+resource "minio_iam_policy" "linkwarden" {
+  name = "linkwarden-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+      ]
+      Resource = [
+        "arn:aws:s3:::linkwarden",
+        "arn:aws:s3:::linkwarden/*",
+      ]
+    }]
+  })
+}
+
+resource "minio_iam_user_policy_attachment" "linkwarden" {
+  user_name   = minio_iam_user.linkwarden.name
+  policy_name = minio_iam_policy.linkwarden.name
+}
+
+# Expire all objects after 180 days
+resource "minio_ilm_policy" "linkwarden" {
+  bucket = minio_s3_bucket.linkwarden.bucket
+
+  rule {
+    id         = "expire-all-180d"
+    expiration = "180d"
+    filter     = ""
+  }
+}
+
+# Output the access key for use in SOPS secrets
+resource "minio_iam_service_account" "linkwarden" {
+  target_user = minio_iam_user.linkwarden.name
+}
+
+output "linkwarden_access_key" {
+  value = minio_iam_service_account.linkwarden.access_key
+}
+
+output "linkwarden_secret_key" {
+  value     = minio_iam_service_account.linkwarden.secret_key
+  sensitive = true
+}

--- a/terraform/local-s3-buckets/mimir.tf
+++ b/terraform/local-s3-buckets/mimir.tf
@@ -1,0 +1,61 @@
+# Bucket
+resource "minio_s3_bucket" "mimir" {
+  bucket = "mimir"
+  acl    = "private"
+}
+
+# Service account with scoped policy
+resource "minio_iam_user" "mimir" {
+  name = "mimir"
+}
+
+resource "minio_iam_policy" "mimir" {
+  name = "mimir-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+      ]
+      Resource = [
+        "arn:aws:s3:::mimir",
+        "arn:aws:s3:::mimir/*",
+      ]
+    }]
+  })
+}
+
+resource "minio_iam_user_policy_attachment" "mimir" {
+  user_name   = minio_iam_user.mimir.name
+  policy_name = minio_iam_policy.mimir.name
+}
+
+# Expire all objects after 90 days
+resource "minio_ilm_policy" "mimir" {
+  bucket = minio_s3_bucket.mimir.bucket
+
+  rule {
+    id         = "expire-all-90d"
+    expiration = "90d"
+    filter     = ""
+  }
+}
+
+# Output the access key for use in SOPS secrets
+resource "minio_iam_service_account" "mimir" {
+  target_user = minio_iam_user.mimir.name
+}
+
+output "mimir_access_key" {
+  value = minio_iam_service_account.mimir.access_key
+}
+
+output "mimir_secret_key" {
+  value     = minio_iam_service_account.mimir.secret_key
+  sensitive = true
+}

--- a/terraform/local-s3-buckets/provider.tf
+++ b/terraform/local-s3-buckets/provider.tf
@@ -1,0 +1,7 @@
+provider "minio" {
+  minio_server   = var.minio_server
+  minio_region   = var.minio_region
+  minio_user     = var.minio_user
+  minio_password = var.minio_password
+  minio_ssl      = true
+}

--- a/terraform/local-s3-buckets/terraform.tf
+++ b/terraform/local-s3-buckets/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state" # Name of the S3 bucket
+    endpoints = {
+      s3 = "https://s3.home399.thiagoalmeida.xyz" # Minio endpoint
+    }
+    key = "local-s3-buckets/terraform.tfstate" # Name of the tfstate file
+
+    access_key = "" # on ./state.config
+    secret_key = ""
+
+    region                      = "main" # Region validation will be skipped
+    skip_credentials_validation = true   # Skip AWS related checks and validations
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_path_style              = true # Enable path-style S3 URLs (https://<HOST>/<BUCKET> https://developer.hashicorp.com/terraform/language/settings/backends/s3#use_path_style
+  }
+}

--- a/terraform/local-s3-buckets/variables.tf
+++ b/terraform/local-s3-buckets/variables.tf
@@ -1,0 +1,23 @@
+variable "minio_region" {
+  type        = string
+  description = "Default MINIO region"
+  default     = "us-east-1"
+}
+
+variable "minio_server" {
+  type        = string
+  description = "Default MINIO host and port"
+  default     = "s3.home399.thiagoalmeida.xyz"
+}
+
+variable "minio_user" {
+  type        = string
+  description = "MINIO user"
+  default     = "minio-root"
+}
+
+variable "minio_password" {
+  type        = string
+  description = "MINIO password"
+  sensitive   = true
+}

--- a/terraform/local-s3-buckets/versions.tf
+++ b/terraform/local-s3-buckets/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    minio = {
+      source  = "aminueza/minio"
+      version = "~> 1.15.0"
+    }
+  }
+  required_version = "~> 1.15.0"
+}


### PR DESCRIPTION
## Summary
- Adds the `terraform/local-s3-buckets` MinIO bucket/IAM module to git (was previously untracked).
- Drops the hardcoded `minio_password` default from `variables.tf` and marks it `sensitive`; provide via `TF_VAR_minio_password`.
- New `.gitignore` mirrors `cloud-backups` and tightens the backend-config exclusion to `state.config*`.