### PR TITLE
feat(databases): point cnpg barman-cloud at rustfs

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/default
-    endpointURL: http://minio.storage.svc.cluster.local:9000
+    endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
         name: cnpg-default-s3-secret

--- a/kubernetes/apps/databases/cnpg-immich/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/immich
-    endpointURL: http://minio.storage.svc.cluster.local:9000
+    endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
         name: cnpg-immich-s3-secret

--- a/kubernetes/apps/databases/cnpg-media/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/media
-    endpointURL: http://minio.storage.svc.cluster.local:9000
+    endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
         name: cnpg-media-s3-secret


### PR DESCRIPTION
## Summary

- Switches all three CNPG ObjectStores (default, media, immich) from `minio.storage.svc.cluster.local:9000` to `rustfs.storage.svc.cluster.local:9000`.
- Completes the S3 cutover started in #2648 — CNPG was still writing to MinIO because its endpoint uses internal Service DNS, not the gateway hostname.
- Existing `cnpg-backups` history mirrored from MinIO to RustFS prior to merge.