### PR TITLE
feat(external-dns): watch TLSRoute

### DIFF
--- a/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
       - --crd-source-kind=DNSEndpoint
       - --gateway-name=external
     policy: sync
-    sources: ["crd", "gateway-httproute"]
+    sources: ["crd", "gateway-httproute", "gateway-tlsroute"]
     txtPrefix: k8s.
     txtOwnerId: default
     domainFilters: ["${PUBLIC_DOMAIN}"]


### PR DESCRIPTION
## Summary
- Add `gateway-tlsroute` to external-dns sources so passthrough hostnames (e.g., kanidm's `auth.${PUBLIC_DOMAIN}`) get public CNAMEs; without this, external-dns deletes the record as soon as the HTTPRoute is removed