### PR TITLE
fix(databases): drop noop backup.retentionPolicy from cnpg-default and cnpg-media

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
@@ -22,7 +22,6 @@ spec:
     size: 10Gi
     storageClass: longhorn
   backup:
-    retentionPolicy: "7d"
     volumeSnapshot:
       className: longhorn-snapshot-class
   plugins:

--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -22,7 +22,6 @@ spec:
     size: 5Gi
     storageClass: longhorn
   backup:
-    retentionPolicy: "7d"
     volumeSnapshot:
       className: longhorn-snapshot-class
   plugins:


### PR DESCRIPTION
## Summary
- `spec.backup.retentionPolicy` is the deprecated in-tree barman-cloud field — silently ignored when the plugin is the WAL archiver, and kubectl emits a warning on apply.
- Plugin retention is configured on each `ObjectStore.spec.retentionPolicy`; this drops the no-op field to match cnpg-immich.