### PR TITLE
fix(auth): use httpGet HTTPS probes for kanidm

### DIFF
--- a/kubernetes/apps/auth/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/kanidm/app/helmrelease.yaml
@@ -45,7 +45,9 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    scheme: HTTPS
+                    path: /status
                     port: &port 8443
                   initialDelaySeconds: 15
                   periodSeconds: 30
@@ -55,7 +57,9 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    scheme: HTTPS
+                    path: /status
                     port: *port
                   initialDelaySeconds: 5
                   periodSeconds: 10


### PR DESCRIPTION
## Summary
- Swap tcpSocket liveness/readiness probes for `httpGet` against `/status` with `scheme: HTTPS`; the previous probes opened TCP without sending a ClientHello and spammed `tls handshake eof` errors in the kanidm logs every ~10s