### PR TITLE
chore(networking): drop kanidm-tls listeners and revert gateway-api crds

### DIFF
--- a/kubernetes/apps/kube-system/gateway-api-crds/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/gateway-api-crds/app/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml

--- a/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
@@ -28,17 +28,6 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-production-tls"
-    - name: kanidm-tls
-      protocol: TLS
-      port: 443
-      hostname: "auth.${PUBLIC_DOMAIN}"
-      tls:
-        mode: Passthrough
-      allowedRoutes:
-        namespaces:
-          from: All
-        kinds:
-          - kind: TLSRoute
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -67,17 +56,6 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-production-tls"
-    - name: kanidm-tls
-      protocol: TLS
-      port: 443
-      hostname: "auth.${PUBLIC_DOMAIN}"
-      tls:
-        mode: Passthrough
-      allowedRoutes:
-        namespaces:
-          from: All
-        kinds:
-          - kind: TLSRoute
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
## Summary
- Removes the `kanidm-tls` passthrough listeners from both external and internal Cilium Gateways.
- Reverts `gateway-api-crds` from `experimental-install.yaml` back to `standard-install.yaml` (TLSRoute/TCPRoute/GRPCRoute CRDs no longer needed).
- Merge **after** the kanidm-app removal PR so the TLSRoute resource is gone before the CRDs disappear.