### PR TITLE
chore(networking): drop kanidm routing from cloudflared and openwrt

### DIFF
--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -44,7 +44,6 @@
     # on purpose — only GitHub calls it.
     public_lan_subdomains:
       - analytics
-      - auth
       - media
       - photos
       - portfolio

--- a/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
@@ -7,10 +7,6 @@
 # from the internet to cloudflared, run `cloudflared tunnel route dns <tunnel> <hostname>`.
 # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
 ingress:
-  - hostname: "auth.${PUBLIC_DOMAIN}"
-    originRequest:
-      originServerName: "auth.${PUBLIC_DOMAIN}"
-    service: https://cilium-gateway-external.networking.svc.cluster.local:443
   - hostname: "*.${PUBLIC_DOMAIN}"
     originRequest:
       http2Origin: true


### PR DESCRIPTION
## Summary
- Removes the dedicated `auth.${PUBLIC_DOMAIN}` rule from cloudflared (the `*.${PUBLIC_DOMAIN}` wildcard remains).
- Drops `auth` from the OpenWrt `public_lan_subdomains` list. Requires running `ansible-playbook ansible/playbooks/openwrt-router.yml` afterwards.