### PR TITLE
feat(storage): add Versity S3 gateway

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./minio/ks.yaml
   - ./rustfs/ks.yaml
   - ./snapshot-controller/ks.yaml
+  - ./versitygw/ks.yaml

--- a/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app versitygw
+  namespace: storage
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 30m
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      versitygw:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: {type: RuntimeDefault}
+        containers:
+          app:
+            image:
+              repository: ghcr.io/versity/versitygw
+              tag: v1.4.1@sha256:0400cb59f59da0f1cf9f7fd49505191abc348dfadf54509bf1988caaff4eb96f
+            args:
+              - --health
+              - /_health
+              - --iam-dir
+              - /iam
+              - posix
+              - --nometa
+              - --disable-copy-file-range
+              - /data
+            env:
+              TZ: "${TIMEZONE:=Etc/UTC}"
+              VGW_PORT: ":7070"
+              VGW_REGION: us-east-1
+            envFrom:
+              - secretRef:
+                  name: versitygw-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_health
+                    port: &port 7070
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_health
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: *app
+        ports:
+          s3:
+            port: *port
+    persistence:
+      data:
+        accessMode: ReadWriteOnce
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-provision
+        size: 30Gi
+        globalMounts:
+          - path: /data
+      iam:
+        accessMode: ReadWriteOnce
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-provision
+        size: 1Gi
+        globalMounts:
+          - path: /iam

--- a/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
@@ -45,6 +45,8 @@ spec:
               - /_health
               - --iam-dir
               - /iam
+              - --webui
+              - ":7071"
               - posix
               - --nometa
               - --disable-copy-file-range
@@ -94,6 +96,19 @@ spec:
         ports:
           s3:
             port: *port
+          webui:
+            port: 7071
+    route:
+      webui:
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["versitygw.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: webui
     persistence:
       data:
         accessMode: ReadWriteOnce

--- a/kubernetes/apps/storage/versitygw/app/kustomization.yaml
+++ b/kubernetes/apps/storage/versitygw/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./versitygw.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/storage/versitygw/app/versitygw.sops.yaml
+++ b/kubernetes/apps/storage/versitygw/app/versitygw.sops.yaml
@@ -1,0 +1,25 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: versitygw-secret
+    namespace: storage
+type: Opaque
+stringData:
+    ROOT_ACCESS_KEY_ID: ENC[AES256_GCM,data:D9yf29p1Y3QY13b25H/yoPfopVSaalpB,iv:xN9TQj8ouose1iMBILPZcdhSW9mrNO0/ZrkuuRVQnU8=,tag:32xk9Kp9gv1Eu2RL+zjqPg==,type:str]
+    ROOT_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:xK1n+K4eR+yPE+4oH8TMcewhFYwRWcA2BISmeqZKpYwz9TTC7BbfSQ==,iv:EwGMbHr4rDlJnOI3UVAHe56me72m9qGv7a++8plObPs=,tag:hD4GigZtIg0eTjlkETRoOg==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5R3EwbFB0ZGhVWURmQWoy
+            MlpTNmZBbjF1OUM0WFJyMm9HdWY3ZmUwMXhNCmVkWml0ZnppOXVlcWhDU1dzZHcz
+            TXUxMTJrNDhKcitqSVcvd1JtV2tkdlkKLS0tIDdEQzJXZUxMKzVISFhtcEExbFNq
+            dkdxZ2t4M1oyUkdZYUcwU2I4YzhqSmsKg3OM8uNuStHR9h3O3f597nZOGtnjSU6g
+            4fjNSYbNF52+sI9I7z4QnLxh9paULpF4IGsA0HvlSEJ7sl8msZSoaA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-16T22:15:41Z"
+    mac: ENC[AES256_GCM,data:ym/g28pG04V9TLxlApOPgbwY1S/aVodZ1fvGNYavtS8/gCCbOVcB5iviRFFDC0HMUHUj/JOe2pQUIM3xXSjhWO5iRfVzl7IUiP4aVvbaKpmyNNm+TKcM5kU4Lj3E9kvTF/oq8QFa2s4JWLZob7tMXCPIGyfQ5Gs23VhttKVbfbY=,iv:P1aKGnHxDvD/uKgJowrao1hGxeOpWDKQOq//9ywuiwg=,tag:AKStkA75vLi60A4mixc/Uw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/storage/versitygw/ks.yaml
+++ b/kubernetes/apps/storage/versitygw/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: versitygw
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/storage/versitygw/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- Deploys Versity S3 Gateway (`ghcr.io/versity/versitygw:v1.4.1`) as a sibling to RustFS, backed by NFS with `--nometa` + `--disable-copy-file-range` for NFS compatibility.
- In-cluster only (`versitygw.storage.svc.cluster.local:7070`) — no HTTPRoute, no consumers wired yet.
- Phase A install of the Versity PoC plan; cutover (`cnpg-default` ObjectStore flip) follows in a separate PR.