### PR TITLE
fix(storage): switch Versity to --sidecar metadata for NFS

### DIFF
--- a/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
@@ -48,7 +48,8 @@ spec:
               - --webui
               - ":7071"
               - posix
-              - --nometa
+              - --sidecar
+              - /sidecar
               - --disable-copy-file-range
               - /data
             env:
@@ -126,3 +127,11 @@ spec:
         size: 1Gi
         globalMounts:
           - path: /iam
+      sidecar:
+        accessMode: ReadWriteOnce
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-provision
+        size: 5Gi
+        globalMounts:
+          - path: /sidecar


### PR DESCRIPTION
## Summary
- `--nometa` silently drops bucket ownership/policy metadata, so non-root users get Access Denied even on their own buckets. Verified in-cluster: `change-bucket-owner` reports success but Owner column stays empty.
- `--sidecar /sidecar` stores metadata in regular files (no xattrs required) — NFS-safe equivalent that preserves ownership/ACLs.
- Adds a 5Gi `sidecar` PVC on `nfs-provision`.