### PR TITLE
feat(databases): cut cnpg-default barman-cloud to Versity

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/default
-    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    endpointURL: http://versitygw.storage.svc.cluster.local:7070
     s3Credentials:
       accessKeyId:
         name: cnpg-default-s3-secret

--- a/kubernetes/apps/databases/cnpg-default/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/secret.sops.yaml
@@ -5,20 +5,20 @@ metadata:
     namespace: databases
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ENC[AES256_GCM,data:umkeT1Dm4JgqsDoC/I596BeoQUY=,iv:cKFrbw13TpnmPiSx+L5WC7iAqFlIJLrzC2rWps+B01E=,tag:C3zaXza8XBLzre3ksAgZmA==,type:str]
-    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:b/NRy7Df4EKyy/LlCx4PuGNbYXll+4Z5Disg/EXCsSc3Xq06sk4WEA==,iv:6m9YmRXe7+zu4ymaOeQHM63+kw1w3Jw0XisTDM/9tkA=,tag:K13e4QSr/B+6UV4bDyVwqA==,type:str]
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:afF/1fCeeoK9Aes=,iv:ohiaB5GQbsAVfG8WgUxr4Gi/SLWd/DxJZ1s6rvVVUIw=,tag:ge+lUZp1aR0M6WilQQIetA==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:el855Zh3DqSiE/ZHGH4z3VqqfeONpfgWxZ+1ip7mK9g9M9KS5fvXww==,iv:GDrDM6wHy2L9NlYB9V389IHL2MmLT0Z2vtmNd3GfdjE=,tag:kWRtWIV9I/qS75mY0M6Jmg==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaMTdvcGtjbDJZakM5b3VB
-            TjhzYW9EWlJ1cFpBaHR5OGJtRkRxWWJGU1M0CkFmRk5XUlZwVUlpdy9FYVlPQ2lN
-            V1BzMUVDMndXWDgxRkVYbWw5T29VblkKLS0tIHhIWDdHbDJDRWY1TnNPNlBTWFVZ
-            Rk00T05mbW9EVE12RmxnUWxPOHJvSFUKliRkl5cK5c71JWodPuSlyN39hoIzhjgM
-            arb1+wofiFm4P9qoit/Vc53WR4D4Gk5s58efMuVZH5RD5AqScJolzQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNV083K215UTQ4N2JhVWpr
+            K0VqSlFZWktObzk3b2ZRZ0xKZjRMZXNTVlVRCmpIVm9lSE9QZ1VmN1ZtTVFqRjhw
+            c0Zxc2NZcWRuVCtYSWRpdzBrdjVuSzAKLS0tIGhPOE9NN0U2L2ZiUkUzYlo5VWIw
+            Z3FRYWlsTXQ2cTJQMjNMQlhRb0NkQ28KU0nMA/Ph97IqWDpYf34tKRhUybgNS82i
+            k9ErNIJ7ewSNqRxss05S+E9tvkE1XeqKeRVOLNOIJWlK8kOfBHlvFA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-14T18:23:06Z"
-    mac: ENC[AES256_GCM,data:uEZkDBECy3lULeabRiZEV9fJxdGZhwD+rWJVqVH666ZSC62wf2LQrWhJzriPSxVDlu+KoRrhm7zfB87Ddc10tpUuyZxYlBNYkw5xke7xy3QVU5sEy+xTPmwyEN8NOirkxKhRDjCLPpgKHHUhQxNWE/g3oPkMf2ZhWnuOvB/Ukk0=,iv:MBvPW54zlCme5eHkNk+wguKlZG/kczEdRXMAMUtvC9I=,tag:dg8gUadOVxcxMGIT4srjtQ==,type:str]
+    lastmodified: "2026-05-16T22:36:07Z"
+    mac: ENC[AES256_GCM,data:2W3LgUlX2ruHc2jm+oVGYmI5Rfz0XwP/unhunW2Dryk2IiIe/vgTEd94TiyqfaMIOlDTr1Nl8WcXek+PPwk2TT6ipY7SLXg2vILvkIzzuItawjuJWr9BhjLiH37GdMWngQPQhJ5FU8CzHOi0zZ1tGW1kj4KwPTguoAWuqVdDwtQ=,iv:ci8/xNprJ2YnR1cNZ5W4QbgLcp8k+iDCg/SFcItNwoY=,tag:/rwxPM3VsYquUeaRIq+lGQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/kubernetes/apps/databases/cnpg-default/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-default/ks.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cluster-apps-cnpg
     - name: cluster-apps-cnpg-barman-cloud
+    - name: versitygw
   path: ./kubernetes/apps/databases/cnpg-default/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- Flips `cnpg-default` ObjectStore endpoint from `rustfs.storage.svc.cluster.local:9000` → `versitygw.storage.svc.cluster.local:7070`.
- Re-encrypts `cnpg-default-s3-secret` with the `cnpg-backup` user provisioned on Versity.
- Adds `versitygw` to the Flux Kustomization `dependsOn`.