### PR TITLE
feat(databases): cut cnpg-media and cnpg-immich barman-cloud to Versity

### DIFF
--- a/kubernetes/apps/databases/cnpg-immich/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/immich
-    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    endpointURL: http://versitygw.storage.svc.cluster.local:7070
     s3Credentials:
       accessKeyId:
         name: cnpg-immich-s3-secret

--- a/kubernetes/apps/databases/cnpg-immich/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/secret.sops.yaml
@@ -5,20 +5,20 @@ metadata:
     namespace: databases
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ENC[AES256_GCM,data:rwFeYvWhK7+QyBmvALeKstrPJfE=,iv:S7ejgHpVbcCfzGmLJEqG2nLLlJQrcFp2YttFIb4VWh4=,tag:fTQj9WH0AyRhXbWmF/ws5g==,type:str]
-    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:A0Yk1kUd6Eq1s/ONqtGBCJ4wxBhTdS2iciHvOj2b6GIFUk34Wl7+xg==,iv:ZfkfXO89aV7q7+/moRrEIQyVMNJ5udUodMpkm4KO0OM=,tag:CThhlG1Wk2ahViYRZYkivw==,type:str]
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:pwMrVo/2NRLrt/I=,iv:LVkfiVqDaRYba8XCCr3sLYyRiGEO0eqrYTC3/Oj+12I=,tag:MOOT0+GTihpq4WaVmxp89w==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:S+rqvAqsT2udytyADSLQtcYIlqqbEmvk+r3uD8MaQvbJUGfJWz33RA==,iv:GtxbxMYOHNJMSH/LmLAPUISvcwa3I0VYhEppRcdYd4Q=,tag:DV1fSgId5M7k5x+zhw/egA==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1RUxpTlB5bUZNbDZNZWh1
-            YkRoSU5qWVpRZ3RPRU8yeC80ZkRaQWhpNFZvClJ1ZXkrTWxWMHl4L2c0V3pLOW9Y
-            R1BBeVQyRUczaWs0dWNJVXcwM0FRNE0KLS0tIG5pZGt4RVUwdFVQUmFyT0w3czNp
-            NlNWeFFiL1lFbWlzTmE3ME9ib04yUXcKh2yUOTONRDlagDrfVg6LjgrVYxgctFY2
-            y8qSgAdwniQnPJ3QrkkisC86icnXbNW5x2ZEXKqYPdMWWQNfNOTwSg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHNVZuQjA2bEc3M3p6cTRz
+            bytrRnA4SU41elNldUE5L3huZk9ORFFySFg4ClUvbk1reWVVT1V3L1ROT3hxc2w2
+            cTlVZnBzSFZYVGx5ZHlBRUNMUFJJK2cKLS0tIGR6MkR2WGRHdVBNQVRFbnQrVGtl
+            eXRkcHJLUVpWZ01KN1U4VkNkaGlzb3cKH4LAa6Pm0dYnOFg+8jpP/tjHcI/HAb7a
+            p0SYG6YftCufPEi6UNq95KkvfkIGZtebMdaCVrPWYYAoVag57Cqw/A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-15T09:49:59Z"
-    mac: ENC[AES256_GCM,data:mx65XTvtfMHExYWad13X/Hkd5TQK5kA6WVeyh8XZ29UMZfmh4dTESHFIVrDK7TlXfdKCdWj+zwIgxLvQkH2O26rRtHtl/BCErO2H5eI9oC3lEMDxRSgsnPPkoLsaifdVrjv9CSLOX/i3B1ZOHYTWoJF4TLYlavs9I7KOJ1aIgkE=,iv:g32MSRggiw4X4LFwhQ4J7jWfF1yfKvki1dGpP9vWpF0=,tag:4J/FE8hBi6Riv1VUuAFVUw==,type:str]
+    lastmodified: "2026-05-16T23:02:35Z"
+    mac: ENC[AES256_GCM,data:sE47GlfNvyd6aQlbVVzlJjUxTRVBch1xF8yDNRDfrh013BuuPSJSY8wIemE6frW4uzTFFwUkKuPkid1jWRN4xeJwImZ8TRhqqBx0DOthxlr54y6dka2M4NLZgPBBqRLyi9N4qijXRVvaMzoMF9NuVjOsA/Gc46mvvkf6fXr4PYU=,iv:QfsokVDADEDOjyAAKQB5unjzf5NV7l6DmWZzR03NJAE=,tag:fnA67BKyQH+lP+yw7dKpuw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/kubernetes/apps/databases/cnpg-immich/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/ks.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cluster-apps-cnpg
     - name: cluster-apps-cnpg-barman-cloud
+    - name: versitygw
   path: ./kubernetes/apps/databases/cnpg-immich/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/databases/cnpg-media/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/media
-    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    endpointURL: http://versitygw.storage.svc.cluster.local:7070
     s3Credentials:
       accessKeyId:
         name: cnpg-media-s3-secret

--- a/kubernetes/apps/databases/cnpg-media/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/secret.sops.yaml
@@ -5,20 +5,20 @@ metadata:
     namespace: databases
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ENC[AES256_GCM,data:SxJ2L1z+Ycl5Oj4DARe0MeVglXU=,iv:eiswsh1uOTPMe2yFR/2O+fr5FhHZ61BSgo6M8N9etgo=,tag:DE5rNyiaFCfHw9l2Zeo08g==,type:str]
-    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:DIpS41CNz7hSR84GwP1I9sbyVUrK1XN8c4ZT8qf1FN/tUPJKaugMHQ==,iv:dK5aqsIeSw1e64XlPmA57Ex8w917fLI2VCj82GqcbG4=,tag:tZKj1P//f6mkRCnh9rkVNQ==,type:str]
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:yqTfkKJJoGXyO78=,iv:rb1kEX8O1C0MNyG3netUL4h0dLaBC+WfUV4REIy+O+s=,tag:jHybP3LuKIr5LDFGhuCYXw==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:bDk1XZXQnpWQxHquBTSOvOEIWqgpbhwQ0p5llkb5X4P+c1aAI8ybbw==,iv:khizZOePLSWinI1LDxi7OBG5z3RjohavdrJG1D0kURY=,tag:ECt7O0pYnnQrZsuksf8/bQ==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwK3dvZHROQTRlMWlKNUt2
-            bDJpSXRwT3V0c1VxTUFsek82Ui9jaW1VVlc0CnBXdHBNWFJmcndpUXVsY1lielNG
-            dzFwR3gyeE1wbG14Yms3NHFhOFp3a0UKLS0tIFRPQUU0Q1owSnhRK0RicUtBTmwz
-            ek9hTCs4Wm1TcEhWTTljSmZnUVJQc0EKau0EckvLNa7KOeZBab/87Axo16OC2+ZH
-            +zaM02NgXBq+B7rsIF2FtjShcKmq8Ug24k6jRM/FXJ4Ijdp/1Ro20A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxSDJrMTFSRmxwZWJIMlBF
+            cTNHa0xJS0JBMFcydzJrR3ZzN215WnVQK2hjCldBdk9QUXZXS01mRVRaVHh4R3Vp
+            RlF0WVI4cUZpaW9ndExVVFFreGpWL3cKLS0tIGREcytLaVdpS3JWeHdqSCtSNjZL
+            a0FUZlRiU2FQZWpieURqYngwKzE5KzAKnyaiDVMJ0nEfTmeMeOugZDO0qWZvfA80
+            5+m0S1MGUeBrcO1LtK8LoHuQX9s1NLq1PQaFLEQ9+sLtUQ7DokhILQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-15T09:50:03Z"
-    mac: ENC[AES256_GCM,data:tQTL9sLCiYH2GRi+iBbyI7/wVozdhqiRdtL5vd6SmeB2pCLEcWTO3QwedhJbF/3/vkmjyrC3yc1P4+i40oB7tVGP3cgf5PfepzNLwZXPioqCyd8majZPf0WUIi5RiujzxN4/lbnJ/80j06MB17R+LDHz7Ync7E0nhb5/nIzqlfM=,iv:66dcrFddYXQLXYGP+mClofUfb1T6cwZocpP4fKBocZk=,tag:BP4ejkmKR7b1wTWS+/a9dQ==,type:str]
+    lastmodified: "2026-05-16T23:02:35Z"
+    mac: ENC[AES256_GCM,data:e+2D6Rl3Lnc/80vRg4pd3/1CxHlmR9cP9yZ0WXZe07OlJGjcObow2mWTifuUIW+CHHE74bwPMx08Qczb1kaQN97kEBYNU3GgOuN4K07s4znx/jwCUAGw+S98cNmlTbaIVqKPOP7hhWLzppkLQWjr6lWtSD8NegPk9cxEKEHvrxY=,iv:t7JCvZlnqChQpunwOoxWuLdG7Gr4BEUYzoyRzXeA9z4=,tag:QTEr6pjKJJUQzEkvcv072Q==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/kubernetes/apps/databases/cnpg-media/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-media/ks.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cluster-apps-cnpg
     - name: cluster-apps-cnpg-barman-cloud
+    - name: versitygw
   path: ./kubernetes/apps/databases/cnpg-media/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- Flips `cnpg-media` and `cnpg-immich` ObjectStore endpoints from `rustfs.storage.svc.cluster.local:9000` → `versitygw.storage.svc.cluster.local:7070`.
- Re-encrypts both per-cluster S3 secrets with the shared `cnpg-backup` Versity user (same user already serving `cnpg-default`; per-cluster isolation via destinationPath prefix as before).
- Adds `versitygw` to both Flux Kustomizations' `dependsOn`.