### PR TITLE
feat(auth): add pocket-id OIDC provider backed by HA cnpg-auth

### DIFF
--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -44,6 +44,7 @@
     # on purpose — only GitHub calls it.
     public_lan_subdomains:
       - analytics
+      - auth
       - media
       - photos
       - portfolio

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./pocket-id/ks.yaml

--- a/kubernetes/apps/auth/namespace.yaml
+++ b/kubernetes/apps/auth/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pocket-id
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+
+  values:
+    controllers:
+      pocket-id:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 2
+        strategy: RollingUpdate
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/pocket-id/pocket-id
+              tag: v2.7.0@sha256:45bdeaf3fcd6d07cf8721e98785d93324bb8e65b586498874c05a3d489c8094e
+            env:
+              APP_URL: https://auth.${PUBLIC_DOMAIN}
+              TRUST_PROXY: "true"
+              FILE_BACKEND: database
+              ANALYTICS_DISABLED: "true"
+              PORT: &port 1411
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: pocket-id-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+
+    service:
+      app:
+        controller: pocket-id
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["auth.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+      public:
+        parentRefs:
+          - name: external
+            namespace: networking
+            sectionName: https
+        hostnames: ["auth.${PUBLIC_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http

--- a/kubernetes/apps/auth/pocket-id/app/kustomization.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/auth/pocket-id/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pocket-id-secret
+    namespace: auth
+type: Opaque
+stringData:
+    ENCRYPTION_KEY: ENC[AES256_GCM,data:vR986hgIRqGdjk7bb5Bo7/LXKAF9jAKv3fXcUE8FEGoe7V0xDeJtFm9N8gE=,iv:olfj5xySLbEelO59N+8Z3TycmYWFwQlPcxuo3P/ntZY=,tag:ymTlAG1g9LVFKJLf1fmfpg==,type:str]
+    DB_CONNECTION_STRING: ENC[AES256_GCM,data:t6fZBdvYP8uUXK4HY3YOd9W6L9ZuxtimsLL9xDNp8+BCYbLxHNnp5b1bAjOAx7Pg3Cb06l7b9/RB4E1893+vdd7BRNZrXxHfz8v0pPXigbk+CvTcIQOQxbvRGFPlg3ZX4HAxjS5n3vv+G9UK8KVeatw0Hzex5HmOW7h33CaIh15WFoPri2zQ12My0w==,iv:FoHBZHPmbETh5V6WEy1ZZptLFNqgMUfvT89G+m8F+NE=,tag:Z8Kwave6Wqew5FPtmX2yaw==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTODE3dHk4b3JlOTUrdkRG
+            OTBIR1NiRnpXeUREZzFsc3AxV0lmWERIZUgwCi93bjVHajJCN2xITjdraUQxNnZw
+            aWhiMHc1enBUQnNXRTd5KzBNV0RjQU0KLS0tIFk2Vnc3UnZtdVBMWWFSKzJUQkQ5
+            VE5CZklWUkhUWVQrWE9EUDhaZFRCZGMKPog+MBuST6llfBbOMnv7n6qBDOsdabkJ
+            kehpMMeDI7w4dEIDd7ulu9F7wQL0uLjeWlFZxYvYsr4P7yXgXf/Oyg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-16T22:45:17Z"
+    mac: ENC[AES256_GCM,data:udPTFAS5SC6EI3ro+JzufXKCCrvSJ/8v531getKLo/9sDXX8a4qXC7URAlUz6gbYRXuCi1dG3YmVk0+0CAdgi7ENNjAfQqlgV7/qLsPehPqsgdlhQExrC4OIhslAHd4IL86MOu9se7NXQsMeD89XWoIk5A4QuelO56Q5rH//2Zs=,iv:M7u8iPcjIwMSXMIwJRRvF5c9zqUE50PdkI8J+BV6V2U=,tag:ID8XR1+RadpFZKmL4EieYQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/auth/pocket-id/ks.yaml
+++ b/kubernetes/apps/auth/pocket-id/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pocket-id
+  namespace: flux-system
+spec:
+  targetNamespace: auth
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-auth
+  path: ./kubernetes/apps/auth/pocket-id/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cnpg-auth
+  namespace: databases
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  inheritedMetadata:
+    labels:
+      recurring-job-group.longhorn.io/backup: enabled
+  bootstrap:
+    initdb:
+      database: pocketid
+      owner: pocketid
+      secret:
+        name: pocketid-credentials
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 768Mi
+  storage:
+    size: 10Gi
+    storageClass: longhorn
+  backup:
+    volumeSnapshot:
+      className: longhorn-snapshot-class
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cnpg-auth-object-store

--- a/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
@@ -28,7 +28,7 @@ spec:
     limits:
       memory: 768Mi
   storage:
-    size: 10Gi
+    size: 2Gi
     storageClass: longhorn
   backup:
     volumeSnapshot:

--- a/kubernetes/apps/databases/cnpg-auth/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./objectstore.yaml
+  - ./podmonitor.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-auth/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/objectstore.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: cnpg-auth-object-store
+  namespace: databases
+spec:
+  configuration:
+    destinationPath: s3://cnpg-backups/auth
+    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-auth-s3-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-auth-s3-secret
+        key: SECRET_ACCESS_KEY
+    wal:
+      compression: bzip2
+    data:
+      compression: bzip2
+  retentionPolicy: "30d"

--- a/kubernetes/apps/databases/cnpg-auth/app/objectstore.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/objectstore.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg-backups/auth
-    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    endpointURL: http://versitygw.storage.svc.cluster.local:7070
     s3Credentials:
       accessKeyId:
         name: cnpg-auth-s3-secret

--- a/kubernetes/apps/databases/cnpg-auth/app/podmonitor.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/podmonitor.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cnpg-auth
+  namespace: databases
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: cnpg-auth
+  podMetricsEndpoints:
+    - port: metrics

--- a/kubernetes/apps/databases/cnpg-auth/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/secret.sops.yaml
@@ -5,21 +5,21 @@ metadata:
     namespace: databases
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ENC[AES256_GCM,data:+lUk6fX7chMvN6gTPwx9h4Qq2IcQD7z5ySQG6+htd2j8,iv:W6WUeDFU2TA8ey7dRD9DqHqk1c0IFW6vJG9LIdIJVRY=,tag:y53EZ2cEb/9Y47Dq0iDG0g==,type:str]
-    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:m7JPINFynPdjHucJDV3g1P4wH7UM9Epx0A/IViEvGAjTkFX46A==,iv:9mMYLa1TKyMhImzsprZ9qvo+uS1cQxSYME7hC6TT4QY=,tag:AHNmkAj4wC/aK7GmOv6RYw==,type:str]
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:2IQdYxFnxBRG9wg=,iv:rWAJ15+EkxWMpb8yfu9E4zelS78n64mRzQxx30pJy6s=,tag:UY6b5ZLb5BDOJ+YR0cS3Rw==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:X4/M63tCFqayo6MU+ib2lmibJRL11T47siEYUjUf6hu4RwUbMbDIKQ==,iv:kujzdNLMawyApIJ5EcEBUxoSkOTyIob8QAdpTFB2WkM=,tag:DQCdNrFyq4fUjLBLyjnjTg==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPbXR3Wmx6UWw1NU9zVnVT
-            MVMvWW5pU2YrSEg2NDdjaFkxRUNLcW1vRXgwCm5oN1hyR0NlMUFTMjI5TnRIYlFF
-            elp1aXE1SWhNYUNNMFJlMVViNlhiS3cKLS0tIHU3bndRYUVCVUNUTURrZEorSTBl
-            VXd6Z2dJelRjOENtV0cwZFlER0VHRXMKcp3GhrH1kbnOY6aFEL53uvB6NIZ2qU9+
-            sgTvUx5Kg+yqiBlh3+0OYuVr3+NFrsoeqvCTLZwIeiaEqKGKsAoFLQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwUFhESEFta2F0TTZhNUIy
+            cWgwUnN6c1BhQUJjMVFGT2hxNXJTTy9HQlE4ClYxWXNwMTVIWnhTWHFUVllsWXlj
+            ZHVWclovV2J2dGkyTm9DY0xqUFBrdncKLS0tIEZReGtOQlR4WDRwZzRldU9KcE1h
+            SzJwcUFhWE9lVzdvR0NqVzBWMzRiSzQKmIXuZ1GFq6VfwfKWMA3HHhZcnvwV1u94
+            AyaFc+cfY5NcAWXtxeH4oPIzQa0PiloZc7mI8jml5JH2grj3xcfIRg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-16T22:45:17Z"
-    mac: ENC[AES256_GCM,data:2bpP2ttawJ8b/gOP6KADTVEZ1KK6jXvk4nUueAMBTNUX+YSJStgQaey63D0WeyjB9zLsklsdl+6ignHbYBTa1taoaB3/vtS5oGf9Bfp7h+zVkCJ1QlGNEyR0UFREUF28Yc51YTSDPUYtofJlLCw8eM3vox78AQjMpswwgO7pPUs=,iv:a9HyEiw8DmRbhrUbp6NIfZkyHkK5wpS4ja5Kptc5Y3M=,tag:2fgdpvIv7BNXvPZ7TWveLQ==,type:str]
+    lastmodified: "2026-05-16T23:28:39Z"
+    mac: ENC[AES256_GCM,data:HeddJQtQXLrURkcc13QS627cXeHPolU9C4IUFbG6EukCVc/6+ht4ocFYsrQfZMqzZoMg+4sYtfyd6woVeyvBP/snCMKUuJ5rFWt7RyVhgBegcHVcFjjH5Oej6OLrdfq5iIgtzBH04cgqAiqIh5KqGDbEXfn0ECA8cNBjNwzUBJ4=,iv:oKN9RQOE7EyrXmbvPI6a3Fp3F1u3JzhPi06H7ky7kMc=,tag:0wNnQDNghQagp/ebiSR4Fg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2
 ---
@@ -30,20 +30,20 @@ metadata:
     namespace: databases
 type: kubernetes.io/basic-auth
 stringData:
-    username: ENC[AES256_GCM,data:tynVev9cuoU=,iv:BKI5CbSSG31KMNx2wZUtKlFhZYKNTavl/D5/RGvdod8=,tag:dhcEgr3TzeNhkAvnH3aEzg==,type:str]
-    password: ENC[AES256_GCM,data:uPt83NfY6Ka50tvFeM1G2EskLWfqzzGQ4GB34VM52JiS91TzLlEOIaCUrS46z2q0,iv:+CGkblay+1YeSkLxunh4k0+uctaCaf5HUg/J1FqpldM=,tag:1VjSCdsFbQLwf7vEb2+iJg==,type:str]
+    username: ENC[AES256_GCM,data:FgOTUL3JTLY=,iv:W31oPbNh0v5SjbkOEiU50v70U0YU+By9737VumyVw4s=,tag:5iCJw+YnSXRVAU03CZWAIA==,type:str]
+    password: ENC[AES256_GCM,data:UqXEaSaEotQyQsH/n1AkPdX/1/4cL6FzvcnTmBJIl10ufGnkS6gWS5cpu8yW4AZy,iv:vmcomLC+lTvILOLHpygc8KOX1EBmnWs232EB3KhxRQo=,tag:baq0lv1c7OO/OfQ3xciDJQ==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPbXR3Wmx6UWw1NU9zVnVT
-            MVMvWW5pU2YrSEg2NDdjaFkxRUNLcW1vRXgwCm5oN1hyR0NlMUFTMjI5TnRIYlFF
-            elp1aXE1SWhNYUNNMFJlMVViNlhiS3cKLS0tIHU3bndRYUVCVUNUTURrZEorSTBl
-            VXd6Z2dJelRjOENtV0cwZFlER0VHRXMKcp3GhrH1kbnOY6aFEL53uvB6NIZ2qU9+
-            sgTvUx5Kg+yqiBlh3+0OYuVr3+NFrsoeqvCTLZwIeiaEqKGKsAoFLQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwUFhESEFta2F0TTZhNUIy
+            cWgwUnN6c1BhQUJjMVFGT2hxNXJTTy9HQlE4ClYxWXNwMTVIWnhTWHFUVllsWXlj
+            ZHVWclovV2J2dGkyTm9DY0xqUFBrdncKLS0tIEZReGtOQlR4WDRwZzRldU9KcE1h
+            SzJwcUFhWE9lVzdvR0NqVzBWMzRiSzQKmIXuZ1GFq6VfwfKWMA3HHhZcnvwV1u94
+            AyaFc+cfY5NcAWXtxeH4oPIzQa0PiloZc7mI8jml5JH2grj3xcfIRg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-16T22:45:17Z"
-    mac: ENC[AES256_GCM,data:2bpP2ttawJ8b/gOP6KADTVEZ1KK6jXvk4nUueAMBTNUX+YSJStgQaey63D0WeyjB9zLsklsdl+6ignHbYBTa1taoaB3/vtS5oGf9Bfp7h+zVkCJ1QlGNEyR0UFREUF28Yc51YTSDPUYtofJlLCw8eM3vox78AQjMpswwgO7pPUs=,iv:a9HyEiw8DmRbhrUbp6NIfZkyHkK5wpS4ja5Kptc5Y3M=,tag:2fgdpvIv7BNXvPZ7TWveLQ==,type:str]
+    lastmodified: "2026-05-16T23:28:39Z"
+    mac: ENC[AES256_GCM,data:HeddJQtQXLrURkcc13QS627cXeHPolU9C4IUFbG6EukCVc/6+ht4ocFYsrQfZMqzZoMg+4sYtfyd6woVeyvBP/snCMKUuJ5rFWt7RyVhgBegcHVcFjjH5Oej6OLrdfq5iIgtzBH04cgqAiqIh5KqGDbEXfn0ECA8cNBjNwzUBJ4=,iv:oKN9RQOE7EyrXmbvPI6a3Fp3F1u3JzhPi06H7ky7kMc=,tag:0wNnQDNghQagp/ebiSR4Fg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/kubernetes/apps/databases/cnpg-auth/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/secret.sops.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cnpg-auth-s3-secret
+    namespace: databases
+type: Opaque
+stringData:
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:+lUk6fX7chMvN6gTPwx9h4Qq2IcQD7z5ySQG6+htd2j8,iv:W6WUeDFU2TA8ey7dRD9DqHqk1c0IFW6vJG9LIdIJVRY=,tag:y53EZ2cEb/9Y47Dq0iDG0g==,type:str]
+    SECRET_ACCESS_KEY: ENC[AES256_GCM,data:m7JPINFynPdjHucJDV3g1P4wH7UM9Epx0A/IViEvGAjTkFX46A==,iv:9mMYLa1TKyMhImzsprZ9qvo+uS1cQxSYME7hC6TT4QY=,tag:AHNmkAj4wC/aK7GmOv6RYw==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPbXR3Wmx6UWw1NU9zVnVT
+            MVMvWW5pU2YrSEg2NDdjaFkxRUNLcW1vRXgwCm5oN1hyR0NlMUFTMjI5TnRIYlFF
+            elp1aXE1SWhNYUNNMFJlMVViNlhiS3cKLS0tIHU3bndRYUVCVUNUTURrZEorSTBl
+            VXd6Z2dJelRjOENtV0cwZFlER0VHRXMKcp3GhrH1kbnOY6aFEL53uvB6NIZ2qU9+
+            sgTvUx5Kg+yqiBlh3+0OYuVr3+NFrsoeqvCTLZwIeiaEqKGKsAoFLQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-16T22:45:17Z"
+    mac: ENC[AES256_GCM,data:2bpP2ttawJ8b/gOP6KADTVEZ1KK6jXvk4nUueAMBTNUX+YSJStgQaey63D0WeyjB9zLsklsdl+6ignHbYBTa1taoaB3/vtS5oGf9Bfp7h+zVkCJ1QlGNEyR0UFREUF28Yc51YTSDPUYtofJlLCw8eM3vox78AQjMpswwgO7pPUs=,iv:a9HyEiw8DmRbhrUbp6NIfZkyHkK5wpS4ja5Kptc5Y3M=,tag:2fgdpvIv7BNXvPZ7TWveLQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pocketid-credentials
+    namespace: databases
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:tynVev9cuoU=,iv:BKI5CbSSG31KMNx2wZUtKlFhZYKNTavl/D5/RGvdod8=,tag:dhcEgr3TzeNhkAvnH3aEzg==,type:str]
+    password: ENC[AES256_GCM,data:uPt83NfY6Ka50tvFeM1G2EskLWfqzzGQ4GB34VM52JiS91TzLlEOIaCUrS46z2q0,iv:+CGkblay+1YeSkLxunh4k0+uctaCaf5HUg/J1FqpldM=,tag:1VjSCdsFbQLwf7vEb2+iJg==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPbXR3Wmx6UWw1NU9zVnVT
+            MVMvWW5pU2YrSEg2NDdjaFkxRUNLcW1vRXgwCm5oN1hyR0NlMUFTMjI5TnRIYlFF
+            elp1aXE1SWhNYUNNMFJlMVViNlhiS3cKLS0tIHU3bndRYUVCVUNUTURrZEorSTBl
+            VXd6Z2dJelRjOENtV0cwZFlER0VHRXMKcp3GhrH1kbnOY6aFEL53uvB6NIZ2qU9+
+            sgTvUx5Kg+yqiBlh3+0OYuVr3+NFrsoeqvCTLZwIeiaEqKGKsAoFLQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-16T22:45:17Z"
+    mac: ENC[AES256_GCM,data:2bpP2ttawJ8b/gOP6KADTVEZ1KK6jXvk4nUueAMBTNUX+YSJStgQaey63D0WeyjB9zLsklsdl+6ignHbYBTa1taoaB3/vtS5oGf9Bfp7h+zVkCJ1QlGNEyR0UFREUF28Yc51YTSDPUYtofJlLCw8eM3vox78AQjMpswwgO7pPUs=,iv:a9HyEiw8DmRbhrUbp6NIfZkyHkK5wpS4ja5Kptc5Y3M=,tag:2fgdpvIv7BNXvPZ7TWveLQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/databases/cnpg-auth/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-auth
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-cnpg
+    - name: cluster-apps-cnpg-barman-cloud
+  path: ./kubernetes/apps/databases/cnpg-auth/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/databases/cnpg-auth/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/ks.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cluster-apps-cnpg
     - name: cluster-apps-cnpg-barman-cloud
+    - name: versitygw
   path: ./kubernetes/apps/databases/cnpg-auth/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./cnpg-auth/ks.yaml
   - ./cnpg-default/ks.yaml
   - ./cnpg-immich/ks.yaml
   - ./cnpg-media/ks.yaml


### PR DESCRIPTION
## Summary

- New `cnpg-auth` Postgres cluster (instances: 2 + pod anti-affinity, barman-cloud → Versity, Longhorn recurring-job snapshots) and a hand-rolled `pocketid` user secret so the password is provisioned at bootstrap.
- `auth` namespace recreated; pocket-id v2.7.0 app-template HelmRelease with `replicas: 2`, `FILE_BACKEND=database` (no PVC), TCP probes on 1411, dual HTTPRoutes on `auth.${PUBLIC_DOMAIN}` (issuer) and `auth.${SECRET_DOMAIN}`.