### PR TITLE
fix(auth): drop pocket-id to replicas:1

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
       pocket-id:
         annotations:
           reloader.stakater.com/auto: "true"
-        replicas: 2
-        strategy: RollingUpdate
+        replicas: 1
+        strategy: Recreate
         pod:
           securityContext:
             runAsUser: 1000


### PR DESCRIPTION
## Summary

- Pocket-id doesn't cleanly tolerate multi-replica (in-process state); the second pod crash-loops on startup. HA stays at the DB layer via cnpg-auth.
- Strategy switched to `Recreate` since single-replica + DB-only state means rolling update offers no benefit.