### PR TITLE
feat(monitoring): cut Loki and Mimir s3 backend to Versity

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/loki/app/secret.sops.yaml
@@ -2,29 +2,25 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: loki-secret
+    namespace: monitoring
 type: Opaque
 stringData:
-    BUCKET_NAME: ENC[AES256_GCM,data:1/SsXQ==,iv:0RLaYsgkLy3tQKpl23PhCNqmCvDqAcM/z3ePhWGMYvg=,tag:o/cKmHrAVzqOWxZY29BOpg==,type:str]
-    BUCKET_HOST: ENC[AES256_GCM,data:xmjqkp45pBRJbP7YYK5qcQz+E5wuMAaX3YTKqqzs85Pc3ADH,iv:PHEpzLJwOtH7D1tETM/qnCPfQkpZ9Hc5BbF3mcPuqJk=,tag:q26CN6rQxm05QZy/SeNrPA==,type:str]
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:1iTKYd7ilu7JjR1WaQIEZUAW950=,iv:XThZewExRX+y35F4d3zfBsgsA5EVLfrTQzEYf0FSNMw=,tag:ORzELB6uFiu5AmeYYN7HnA==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:662eIkj5owl7KlN6VZwqDFXJhGOPwCPXUzoFl3lKw81JWqnY3IbVLQ==,iv:RLe8bKiYU7f48e2dIZaKSZZQwemx4eo7gLv8UJHQAy0=,tag:SaNi/vsSVROXTA3Wc5pxxQ==,type:str]
+    BUCKET_NAME: ENC[AES256_GCM,data:fSDQbQ==,iv:eqwHLUOQjnbIxsMViz5E5ZBd14YFK+1QTEYpegP5K/s=,tag:7mDv7Gsa9CdY+K9sTFK4eg==,type:str]
+    BUCKET_HOST: ENC[AES256_GCM,data:hTxM+MusBduJnP3RHu8rhJuuyaRugN4LZb28v61FPVa4Trzj40O24ITNcOD+BD4=,iv:duRmZK5+Bf0/MTAMpyjZssNoblEJ3SdCBmswG3I+HrA=,tag:uTrrPudunFqIndfVOfF65Q==,type:str]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:PNgu0A==,iv:Q1I4knCWXfChyQnJ8QWs5GKZHzngLJXbJzywqwVx8iE=,tag:SXoP6yb+QnqbW4GPOljQsA==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:9Ue5K3YAQpYz+VUgBbLQFw0MDBKSKLvMkYzzKDnLa2p8NlIJi1yLiA==,iv:LygWPEoO7An9DFjMT7pALKCnu//oqvG1mePajP5BZ7w=,tag:POL2FrwXGDvOXYwDmaQwBA==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArU204UStDQzF6NDMwc3d4
-            OWpnOVFrMTQwWktDN2RpMk5vRW9SSk1pWFZRCnF4Wjh2aEhncVk4RVVUUSt1cjdH
-            YTREQWJyZjRzcXBiQUk2THhLdFhnYlkKLS0tIDVqeG9RUkFycy9KWS9tdm81amNa
-            QmtKWDU5TFlhV2I4VDJMRmdvd2JuWE0KeKHlNF79fNynP1CfNttfecerB6Cp4MwR
-            7Q5x8Ch32hVdna/3rtxmhFg62/Q/4GGsKDdaQ5Wa67OLsMas6lJFLw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxakVlQTdRajlvZzFRSk1F
+            Y3ZkVnFVSXlhSUR0UWdEZllreDZoSFdPRmtrCjFBRmJXT2lBN2d1RDFORXN0MkRo
+            bWtOQlRtUS9LdEI2NXdxRUpMYmh2M2MKLS0tIHV1WUlOTmRjbWJvcmI4NXl0cDEz
+            KzBVWU5YTXBtZG90MHU1dlk3a1V0dUEKPHcp79copK5C9dseYyri4bM69vkM58JO
+            LOr0HMoN22bj3sMMIG3462OcPVdZR8dCgWVMHLfM0sAPAtQoOH6WCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-08T17:52:11Z"
-    mac: ENC[AES256_GCM,data:Abj//PMTqDowyN1gNBQYl8ogGGm1TqR4oAhYojRSMhl/JR30dk7gz1EWFCthzWvB+T0gXB+t70RKeXHO/lgwlJ9GKh0u3ZqtkAodfZCF+0VHZiOacUAqfO+u4ic0Gd7Al+ST3ImZTWv9TExZemw9TyRRaZzMgy0zjhJ7rQ7wurU=,iv:HwpPtjTLZnBwvTOwd4+DWVBOBTbQH4j+D5o3tfcIFgA=,tag:Kp8s4EqUDFqfmUTH8UwHTA==,type:str]
-    pgp: []
+    lastmodified: "2026-05-16T23:27:22Z"
+    mac: ENC[AES256_GCM,data:yzsLzejkwu4Sr5Z3pPKciEjE4xsJRctFre6xzEY5ZUPtbkW97Dxo3Du/YTtWJDiu4mgDhuNUjs8iqMQNDuoGNPD5EVNyOBS+Cef5kai0odZT7I+c54Pmt97s3ItcfH3OqF2F2lJuBXgzyMEQJe3e55RQ+R4JJm+sOsQVNJjzaSg=,iv:uanRo7hzWJECAXPY0gLFfcp6WR67VK7kj3Y5YhIU6xQ=,tag:644mLXsrAiA568Iw+jvFeg==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.9.0
+    version: 3.10.2

--- a/kubernetes/apps/monitoring/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/mimir/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
                   endpoint: $${BUCKET_HOST}
                   access_key_id: $${AWS_ACCESS_KEY_ID}
                   secret_access_key: $${AWS_SECRET_ACCESS_KEY}
-                  insecure: false
+                  insecure: true
                   bucket_lookup_type: path
 
             distributor:

--- a/kubernetes/apps/monitoring/mimir/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/mimir/app/secret.sops.yaml
@@ -2,23 +2,24 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: mimir-secret
+    namespace: monitoring
 type: Opaque
 stringData:
-    BUCKET_HOST: ENC[AES256_GCM,data:NYFuBjTbXA8C40YXnkN89HItbQ97X7SeFZKi7w==,iv:1LsoYIDQb2dJNkHg2RXVjvaQwpHcVM3UpRtgOJfpGUk=,tag:Gk/NDppMRjdDvxGypuINQQ==,type:str]
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:KPRP9+ZL/pY+X8OaqKV4h2eiLmo=,iv:PsxAmXLoncWudAS5t+apaqbLPy4aMPijc5H2b5HLozw=,tag:EfmwAVMb2p5sTIYb6VqogA==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:J8ujtun3WX1n9ZbE/Vw9FZ0MDHhMt9t5tjmaD6HsVbtt0G6T1dXpUg==,iv:h66+N7Pg/F9mhAtxJhLS9VKLOIzZZ/w/rB2UjM49q4U=,tag:1WzV6suhqBVg3pFGxlWyDQ==,type:str]
+    BUCKET_HOST: ENC[AES256_GCM,data:/2WqQWRA5IVWTQ5XC7RlqttKOCs9P8Utiu/VQq7o+j1ScqbSceTyVg==,iv:FKKTcs5nOLbmCISKclZbtv/E/GHTkLqdYRkRgNMzGHE=,tag:+ehFMaSzBMlOVCwqvQ31fQ==,type:str]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:HLnBWLk=,iv:XEHTbvQYhrq8Z145E3RM+XH3oRtuo9QM3jTTqs0Vyrs=,tag:OGmfsSmM3VlWxJ/VPEdl4A==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:u3YFL04+jUXDeQKvexOQkItKLbRY6Y80cgjcGuG6E9PIs1QcdZX8VA==,iv:MWjwN7LaliKn2o5eEebJb0X5knehLO2WPecctPGmOwc=,tag:HDSyin6Jd8jRaeNYa4xutg==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFcW5rSXY3UmYrOTdSY0Fj
-            M29lL1FERDNqZXdhWHVac0F1YUdhN0lEQkJ3Ckx4WEZrem4xMkZ4cFcyWUlCbHRk
-            ZUNRSWw5TjhaS2hRVFB6RTdkRlJxQkkKLS0tIEJCYklYYmFTS1lFN09jUm1iaVBP
-            VG9LclFzTzk4THBFaUUrbzZnSlFqNEEKJOCMvJD2F+ujlx8/zA++LY6/aTo0dQXf
-            bOpEv8PH9VdsjdQVRNi5okjELcMPRJXNZLO5Osgtau2fapkVoTpzjA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5TUdLbUw5RkpSNG5aNUR1
+            bm84emMxZHUwNll5VlFMNU9iemY3eEhZaUhJCkZjb1RoZkVQc1JGdnVlTTFCYlNo
+            Ri9vRXB5aWVQaFhjNW5oZVZqTU9VQmMKLS0tIHI0Z0k4b0p0YWllVVIrNVl3cmd5
+            R1V1aEJNeHhMZEhRcW0xeEY0SmdsMFUKCUcz1ogHBhdwDQKxDZ2xqnTKFgowK6oe
+            GI6GCptgQBtg/TCo7AUyJvi+Hp1gkMc/6g3odD5gh3kGdK64nkqcgA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-19T12:28:26Z"
-    mac: ENC[AES256_GCM,data:x9pkOrilfKDKvKtNvShOeMmjN1jk5XqeBo5BqPQ9gUA46EG2m+11hxob3hTEmc+wImnLfyx3MMw3xp3nTYgi811Mknn9cbI/WZ76Z3CQq2FAY27vPE3+yLrgaxfSqL0Sd7pw4Q5y4ofCPieYa3IdjSHP7Uf3mXliEJcU1QSMGnA=,iv:IQL11qTPavyebldXcKCYQqwCU2N+YwD/sNL/ntqygjg=,tag:z/QRO252WtPcFPQGJSdJXA==,type:str]
+    lastmodified: "2026-05-16T23:27:22Z"
+    mac: ENC[AES256_GCM,data:2KeiOdK8oZZcEhUTJmaaqAmtXgtokI7ntEiFRn18xKZ9jFXNvewTs/kMsfXpKgt0zFZjQwxCzfNk1FlRRlORgQyrKX+atbg07tk597R5Zb+olDn5CABYgjqDYcmKGlI+dqFv6C4NWdIah+5lhRAF70Wl/Yuue3SxBtK+BubD0sg=,iv:z1AcGcOH78a5e21Gaf/d6ALRFvjAKfdXpO5y7GxbN9I=,tag:G6k+nWI1JHcA/Hlnnnuy2g==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary
- Repoints `loki-secret` and `mimir-secret` from `s3.home399.thiagoalmeida.xyz` (RustFS via external HTTPRoute) to internal `versitygw.storage.svc.cluster.local:7070`. New per-app users (`loki`, `mimir`) bootstrapped on Versity.
- Mimir helmrelease `insecure: false` → `true` since the internal Service serves plain HTTP (TLS terminates at the Cilium gateway, not at the pod).
- Fresh start, no data migration — existing chunks/blocks on RustFS are abandoned.
- After merge, Loki pods may need a manual `kubectl rollout restart` (no Stakater reloader on grafana/loki chart); Mimir reloads automatically.