### PR TITLE
feat(auth): enable drift detection on pocket-id

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -18,6 +18,8 @@ spec:
     remediation:
       retries: 3
       strategy: rollback
+  driftDetection:
+    mode: enabled
 
   values:
     controllers:


### PR DESCRIPTION
## Summary

- Sets `driftDetection.mode: enabled` on the pocket-id HelmRelease, matching umami and headlamp. Flux will re-apply chart manifests if cluster state diverges from the last release.