### PR TITLE
refactor(auth): consolidate pocket-id httproutes

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -92,20 +92,15 @@ spec:
     route:
       app:
         parentRefs:
-          - name: internal
-            namespace: networking
-            sectionName: https
-        hostnames: ["auth.${SECRET_DOMAIN}"]
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: http
-      public:
-        parentRefs:
           - name: external
             namespace: networking
             sectionName: https
-        hostnames: ["auth.${PUBLIC_DOMAIN}"]
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames:
+          - "auth.${SECRET_DOMAIN}"
+          - "auth.${PUBLIC_DOMAIN}"
         rules:
           - backendRefs:
               - identifier: app


### PR DESCRIPTION
## Summary

- Collapses `pocket-id-app` (internal-only, SECRET_DOMAIN) and `pocket-id-public` (external-only, PUBLIC_DOMAIN) into a single HTTPRoute with both hostnames and both parentRefs. Matches the pattern #2675 established for jellyfin / immich / photoprism. After this merges, `pocket-id-public` is GC'd by Flux.