### PR TITLE
feat(networking): scope external gateway hostname, merge split httproutes

### DIFF
--- a/kubernetes/apps/default/immich/app/server/httproute.yaml
+++ b/kubernetes/apps/default/immich/app/server/httproute.yaml
@@ -12,23 +12,6 @@ metadata:
     gethomepage.dev/description: Manage Photos
 spec:
   parentRefs:
-    - name: internal
-      namespace: networking
-      sectionName: https
-  hostnames:
-    - "photos.${SECRET_DOMAIN}"
-  rules:
-    - backendRefs:
-        - name: immich-server
-          port: 2283
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: immich-public
-  namespace: default
-spec:
-  parentRefs:
     - name: external
       namespace: networking
       sectionName: https
@@ -36,6 +19,7 @@ spec:
       namespace: networking
       sectionName: https
   hostnames:
+    - "photos.${SECRET_DOMAIN}"
     - "photos.${PUBLIC_DOMAIN}"
   rules:
     - backendRefs:

--- a/kubernetes/apps/default/photoprism/app/httproute.yaml
+++ b/kubernetes/apps/default/photoprism/app/httproute.yaml
@@ -12,23 +12,6 @@ metadata:
     gethomepage.dev/description: Manage Photos
 spec:
   parentRefs:
-    - name: internal
-      namespace: networking
-      sectionName: https
-  hostnames:
-    - "portfolio.${SECRET_DOMAIN}"
-  rules:
-    - backendRefs:
-        - name: photoprism
-          port: 2342
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: photoprism-public
-  namespace: default
-spec:
-  parentRefs:
     - name: external
       namespace: networking
       sectionName: https
@@ -36,6 +19,7 @@ spec:
       namespace: networking
       sectionName: https
   hostnames:
+    - "portfolio.${SECRET_DOMAIN}"
     - "portfolio.${PUBLIC_DOMAIN}"
   rules:
     - backendRefs:

--- a/kubernetes/apps/media/jellyfin/app/httproute.yaml
+++ b/kubernetes/apps/media/jellyfin/app/httproute.yaml
@@ -11,28 +11,6 @@ metadata:
     gethomepage.dev/icon: jellyfin.png
 spec:
   parentRefs:
-    - name: internal
-      namespace: networking
-      sectionName: https
-  hostnames:
-    - "media.${SECRET_DOMAIN}"
-  rules:
-    - backendRefs:
-        - name: jellyfin
-          port: 8096
----
-# Public jellyfin route. The legacy nginx config returned 404 for /metrics
-# to keep the exporter off the public surface. Gateway API v1 has no native
-# `directResponse` filter; the exporter Service is a separate endpoint, so
-# /metrics on this hostname only exposes whatever jellyfin itself serves on
-# that path (not the prometheus exporter).
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: jellyfin-public
-  namespace: media
-spec:
-  parentRefs:
     - name: external
       namespace: networking
       sectionName: https
@@ -40,6 +18,7 @@ spec:
       namespace: networking
       sectionName: https
   hostnames:
+    - "media.${SECRET_DOMAIN}"
     - "media.${PUBLIC_DOMAIN}"
   rules:
     - backendRefs:

--- a/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
+++ b/kubernetes/apps/networking/cilium-gateway/app/gateway.yaml
@@ -15,12 +15,14 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+      hostname: "*.${PUBLIC_DOMAIN}"
       allowedRoutes:
         namespaces:
           from: Same
     - name: https
       protocol: HTTPS
       port: 443
+      hostname: "*.${PUBLIC_DOMAIN}"
       allowedRoutes:
         namespaces:
           from: All


### PR DESCRIPTION
## Summary

- Add `hostname: "*.${PUBLIC_DOMAIN}"` on both `external` Gateway listeners so the gateway filters by hostname; internal listeners unchanged for LAN hairpin avoidance.
- Collapse the `<app>` + `<app>-public` HTTPRoute pairs for jellyfin, immich, and photoprism into single routes carrying both hostnames and both parentRefs.