### PR TITLE
feat(ocis): switch oidc backend to pocket-id, disable built-in idp

### DIFF
--- a/kubernetes/apps/default/ocis/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ocis/app/helmrelease.yaml
@@ -51,6 +51,16 @@ spec:
               PROXY_DEBUG_ADDR: 0.0.0.0:9205
               PROXY_TLS: false
               TZ: ${TIMEZONE}
+              OCIS_EXCLUDE_RUN_SERVICES: idp
+              OCIS_OIDC_ISSUER: https://auth.${PUBLIC_DOMAIN}
+              WEB_OIDC_METADATA_URL: https://auth.${PUBLIC_DOMAIN}/.well-known/openid-configuration
+              WEB_OIDC_CLIENT_ID: e31855d0-8b46-408e-94a3-37f96ab0effb
+              WEB_OIDC_SCOPE: openid profile email groups
+              PROXY_AUTOPROVISION_ACCOUNTS: true
+              PROXY_OIDC_REWRITE_WELLKNOWN: true
+              PROXY_USER_OIDC_CLAIM: preferred_username
+              PROXY_ROLE_ASSIGNMENT_DRIVER: oidc
+              PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM: groups
             envFrom:
               - secretRef:
                   name: ocis-secret


### PR DESCRIPTION
## Summary

- Point oCIS proxy/web at pocket-id (`auth.${PUBLIC_DOMAIN}`) for OIDC.
- `OCIS_EXCLUDE_RUN_SERVICES: idp` disables the built-in Konnect IDP.
- Auto-provision accounts; roles via `groups` claim.

Requires an `admin` group + user assignment in pocket-id, plus a data wipe (PVC + NFS) before first login since the built-in IdM user IDs are no longer valid.