### PR TITLE
fix(monitoring): set loki s3.region to match Versity strict signing

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -96,6 +96,7 @@ spec:
           ruler: loki-ruler
           admin: loki-admin
         s3:
+          region: us-east-1
           s3ForcePathStyle: true
           insecure: false
 


### PR DESCRIPTION
## Summary
- Loki S3 client defaults to `region=dummy`. MinIO/RustFS accept it; Versity is strict and rejects with `AuthorizationHeaderMalformed`. Loki crash-loops on startup → kstatus reports the STS as Failed → helm-controller declares "stalled" and rolls back → the rendered ConfigMap reverts to the old RustFS endpoint. The visible symptom looked like Flux being aggressive, but it was a correct signal — Loki was actually crashing.
- Set `loki.storage.s3.region: us-east-1` to match Versity's `VGW_REGION`. Once merged + HR resumed, the upgrade should complete cleanly.