### PR TITLE
fix(ocis): allow pocket-id origin in proxy CSP

### DIFF
--- a/kubernetes/apps/default/ocis/app/config/csp.yaml
+++ b/kubernetes/apps/default/ocis/app/config/csp.yaml
@@ -1,0 +1,38 @@
+---
+directives:
+  child-src:
+    - "'self'"
+  connect-src:
+    - "'self'"
+    - "blob:"
+    - "https://auth.${PUBLIC_DOMAIN}"
+    - "https://raw.githubusercontent.com/owncloud/awesome-ocis/"
+  default-src:
+    - "'none'"
+  font-src:
+    - "'self'"
+    - "data:"
+  frame-ancestors:
+    - "'self'"
+  frame-src:
+    - "'self'"
+    - "blob:"
+    - "https://auth.${PUBLIC_DOMAIN}"
+  img-src:
+    - "'self'"
+    - "data:"
+    - "blob:"
+    - "https://raw.githubusercontent.com/owncloud/awesome-ocis/"
+  manifest-src:
+    - "'self'"
+  media-src:
+    - "'self'"
+  object-src:
+    - "'self'"
+    - "blob:"
+  script-src:
+    - "'self'"
+    - "'unsafe-inline'"
+  style-src:
+    - "'self'"
+    - "'unsafe-inline'"

--- a/kubernetes/apps/default/ocis/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ocis/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
               PROXY_USER_OIDC_CLAIM: preferred_username
               PROXY_ROLE_ASSIGNMENT_DRIVER: oidc
               PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM: groups
+              PROXY_CSP_CONFIG_FILE_LOCATION: /etc/ocis/csp.yaml
             envFrom:
               - secretRef:
                   name: ocis-secret
@@ -137,6 +138,9 @@ spec:
         globalMounts:
           - path: /etc/ocis/web.yaml
             subPath: web.yaml
+            readOnly: true
+          - path: /etc/ocis/csp.yaml
+            subPath: csp.yaml
             readOnly: true
       data:
         type: nfs

--- a/kubernetes/apps/default/ocis/app/kustomization.yaml
+++ b/kubernetes/apps/default/ocis/app/kustomization.yaml
@@ -9,5 +9,6 @@ configMapGenerator:
   - name: ocis
     files:
       - web.yaml=./config/web.yaml
+      - csp.yaml=./config/csp.yaml
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## Summary

- Add `csp.yaml` overriding the proxy's default Content-Security-Policy to allow `https://auth.${PUBLIC_DOMAIN}` in `connect-src` and `frame-src`.
- Set `PROXY_CSP_CONFIG_FILE_LOCATION=/etc/ocis/csp.yaml` and mount the file from the existing `ocis` configMap.
- Without this, the browser blocks `/.well-known/openid-configuration` fetch against pocket-id — login never starts. Documented pattern from the [oCIS Keycloak deployment example](https://github.com/owncloud/ocis/blob/v8.0.3/deployments/examples/ocis_keycloak/config/ocis/csp.yaml) and the [pocket-id oCIS integration guide](https://pocket-id.org/docs/client-examples/oCIS).