### PR TITLE
feat(ocis): enable drift detection on helmrelease

### DIFF
--- a/kubernetes/apps/default/ocis/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ocis/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
+  driftDetection:
+    mode: enabled
   values:
     controllers:
       ocis:


### PR DESCRIPTION
## Summary

- Mirrors the pocket-id helmrelease change (#2673) so in-cluster drift (e.g. ad-hoc `kubectl set env`) self-heals back to the git-managed spec.