### PR TITLE
feat(monitoring): wire grafana to pocket-id oidc

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -355,14 +355,30 @@ spec:
       forceDeployDashboards: true
       defaultDashboardsTimezone: "Europe/Stockholm"
       folderAnnotation: grafana_folder
+      envFromSecret: grafana-secret
       env:
         GF_EXPLORE_ENABLED: true
       grafana.ini:
         users:
           viewers_can_edit: false
-        auth.anonymous:
+        server:
+          root_url: https://grafana.${SECRET_DOMAIN}
+        auth:
+          disable_login_form: true
+        auth.generic_oauth:
           enabled: true
-          org_role: Viewer
+          name: Pocket ID
+          icon: signin
+          allow_sign_up: true
+          auto_login: true
+          client_id: fe8ac74c-e731-4644-bcd4-6ae4c07b6f9a
+          scopes: openid email profile groups
+          auth_url: https://auth.${PUBLIC_DOMAIN}/authorize
+          token_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/token
+          api_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/userinfo
+          use_pkce: true
+          role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || contains(groups[*], 'grafana-editors') && 'Editor' || 'Viewer'
+          allow_assign_grafana_admin: true
       dashboardProviders:
         dashboardproviders.yaml:
           apiVersion: 1

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -377,7 +377,8 @@ spec:
           token_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/token
           api_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/userinfo
           use_pkce: true
-          role_attribute_path: contains(groups[*], 'grafanaAdmins') && 'Admin' || contains(groups[*], 'grafanaEditors') && 'Editor' || 'Viewer'
+          role_attribute_path: contains(groups[*], 'grafanaAdmins') && 'Admin' || contains(groups[*], 'grafanaEditors') && 'Editor' || contains(groups[*], 'grafanaViewers') && 'Viewer'
+          role_attribute_strict: true
           allow_assign_grafana_admin: true
       dashboardProviders:
         dashboardproviders.yaml:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -377,7 +377,7 @@ spec:
           token_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/token
           api_url: https://auth.${PUBLIC_DOMAIN}/api/oidc/userinfo
           use_pkce: true
-          role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || contains(groups[*], 'grafana-editors') && 'Editor' || 'Viewer'
+          role_attribute_path: contains(groups[*], 'grafanaAdmins') && 'Admin' || contains(groups[*], 'grafanaEditors') && 'Editor' || 'Viewer'
           allow_assign_grafana_admin: true
       dashboardProviders:
         dashboardproviders.yaml:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrelease.yaml
   - httproute.yaml
   - prometheusrule.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-secret
+    namespace: monitoring
+type: Opaque
+stringData:
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:MTwX3lomLk5GByrJpLJ3eb4qmO3KkTyjO6YUQXreajc=,iv:MPHVl7uqGH5ve1O4GV6BisUaA12TyBKnvIBYJqdA4uE=,tag:m5VN3kbJnQlMk/ok0/7/tg==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXZU56K1BGUm90REtqcjhF
+            Yk5TY1lBUHJNZGpicytHWFJKRFNSVjNqbEM0CmQzSFd4M2JOOTUzVGxGcXJqWENS
+            WlIvR2RaSC9aQjEyOUtVT3lrYmREczQKLS0tIGlrZGhyZ0V6bTZvVGovZXAwRHlV
+            anNMUWhPM1VxQUhFWkE5TTBSR2pDYWcKxNmCZfWCjSrs1c1A2/4vL2WaUOnO+YpN
+            pwVF8IbLwS17iT51yjvKjUYpN/rUvHqlwSGyniCY+n2CuXeOIwZMUg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-17T02:16:40Z"
+    mac: ENC[AES256_GCM,data:F7m5ND+Os4lec01BOHRRWaAzrGt0HKUUrUFZqPKfQhoRlKGAiD25IcTa6HdyefRY53IG0HMusSJiGKSckAiut7EcFGtT0CQCYjAbvepPMpfKRt1+UGmskMWBqWcYdmhEzDYkwBwNfh45qzpCSUDd4rTKy93mFmQNwh6TRYAYGQY=,iv:JR3zF8t28vV0dnohV/G4ECuX+WthOm/yB0uc8pmKtJ0=,tag:2/UtPomEX864OnpIzuE1Lg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
## Summary

- Add `auth.generic_oauth` to Grafana with Pocket-ID as the IdP — PKCE on, auto-login enabled, anonymous + Grafana login form disabled.
- Gate access on Pocket-ID group membership (`role_attribute_strict: true`, no fallback): `grafanaAdmins` → Admin (+ Server Admin), `grafanaEditors` → Editor, `grafanaViewers` → Viewer.
- Client secret in new SOPS-encrypted `grafana-secret` loaded via `envFromSecret`.