### PR TITLE
fix(n8n): point editor base URL at SECRET_DOMAIN for OAuth callback

### DIFF
--- a/hacks/sops-subs-apply.sh
+++ b/hacks/sops-subs-apply.sh
@@ -10,8 +10,8 @@ load_env_vars() {
     local cluster_secret_file="./kubernetes/flux/vars/cluster-secrets.sops.yaml"
     local cluster_config_file="./kubernetes/flux/vars/cluster-settings.yaml"
 
-    while read -r line; do declare -x "${line}"; done < <(sops -d "${cluster_secret_file}" | yq eval '.stringData' - | sed 's/: /=/g')
-    while read -r line; do declare -x "${line}"; done < <(yq eval '.data' "${cluster_config_file}" | sed 's/: /=/g')
+    while read -r line; do export "${line}"; done < <(sops -d "${cluster_secret_file}" | yq eval '.stringData' - | sed 's/: /=/g')
+    while read -r line; do export "${line}"; done < <(yq eval '.data' "${cluster_config_file}" | sed 's/: /=/g')
 }
 
 decrypt_sops_secrets() {

--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -48,12 +48,12 @@ spec:
               N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: false
               N8N_PROTOCOL: "https"
               N8N_PORT: &port 8080
-              N8N_HOST: &hostName n8n.${PUBLIC_DOMAIN}
+              N8N_HOST: &hostName n8n.${SECRET_DOMAIN}
               N8N_LOG_LEVEL: info
               N8N_LOG_OUTPUT: console
               N8N_PROXY_HOPS: 1
               WEBHOOK_URL: https://n8n.${PUBLIC_DOMAIN}/
-              N8N_EDITOR_BASE_URL: https://n8n.${PUBLIC_DOMAIN}/
+              N8N_EDITOR_BASE_URL: https://n8n.${SECRET_DOMAIN}/
             envFrom:
               - secretRef:
                   name: n8n-secret


### PR DESCRIPTION
## Summary
- Point `N8N_HOST` and `N8N_EDITOR_BASE_URL` at `SECRET_DOMAIN` so OAuth callbacks land on the same host the editor session cookie is bound to. `WEBHOOK_URL` stays on `PUBLIC_DOMAIN` for external webhooks.
- Cherry-pick `858afb3f` — export cluster vars in `hacks/sops-subs-apply.sh`.