### PR TITLE
feat(databases): schedule weekly cnpg base backups via barman-cloud plugin

### DIFF
--- a/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
@@ -11,6 +11,7 @@ spec:
   inheritedMetadata:
     labels:
       recurring-job-group.longhorn.io/backup: enabled
+      recurring-job.longhorn.io/source: enabled
   bootstrap:
     initdb:
       database: pocketid

--- a/kubernetes/apps/databases/cnpg-auth/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./cluster.yaml
   - ./objectstore.yaml
   - ./podmonitor.yaml
+  - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-auth/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cnpg-auth-weekly
+  namespace: databases
+spec:
+  schedule: "0 0 5 * * 0"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: cnpg-auth
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
@@ -11,6 +11,7 @@ spec:
   inheritedMetadata:
     labels:
       recurring-job-group.longhorn.io/backup: enabled
+      recurring-job.longhorn.io/source: enabled
   bootstrap:
     initdb:
       database: hass

--- a/kubernetes/apps/databases/cnpg-default/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./objectstore.yaml
   - ./podmonitor.yaml
   - ./prometheusrule.yaml
+  - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-default/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cnpg-default-weekly
+  namespace: databases
+spec:
+  schedule: "0 0 5 * * 0"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: cnpg-default
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/databases/cnpg-immich/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/cluster.yaml
@@ -11,6 +11,7 @@ spec:
   inheritedMetadata:
     labels:
       recurring-job-group.longhorn.io/backup: enabled
+      recurring-job.longhorn.io/source: enabled
   postgresql:
     shared_preload_libraries:
       - vchord.so

--- a/kubernetes/apps/databases/cnpg-immich/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./cluster.yaml
   - ./objectstore.yaml
   - ./podmonitor.yaml
+  - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-immich/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cnpg-immich-weekly
+  namespace: databases
+spec:
+  schedule: "0 0 5 * * 0"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: cnpg-immich
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -11,6 +11,7 @@ spec:
   inheritedMetadata:
     labels:
       recurring-job-group.longhorn.io/backup: enabled
+      recurring-job.longhorn.io/source: enabled
   bootstrap:
     initdb:
       database: seer

--- a/kubernetes/apps/databases/cnpg-media/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./cluster.yaml
   - ./objectstore.yaml
   - ./podmonitor.yaml
+  - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-media/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cnpg-media-weekly
+  namespace: databases
+spec:
+  schedule: "0 0 5 * * 0"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: cnpg-media
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/databases/mariadb/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mariadb/app/helmrelease.yaml
@@ -36,6 +36,9 @@ spec:
     persistence:
       storageClass: longhorn
       size: 2Gi
+      labels:
+        recurring-job-group.longhorn.io/backup: enabled
+        recurring-job.longhorn.io/source: enabled
     primary:
       pdb:
         create: true

--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -77,6 +77,9 @@ spec:
         retain: true
         size: 10Gi
         storageClass: longhorn
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /home/node/.n8n
     route:

--- a/kubernetes/apps/default/photoprism/app/helmrelease.yaml
+++ b/kubernetes/apps/default/photoprism/app/helmrelease.yaml
@@ -93,6 +93,9 @@ spec:
         storageClass: longhorn
         size: 7Gi
         retain: true
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: *storage
 

--- a/kubernetes/apps/default/pingvin-share/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pingvin-share/app/helmrelease.yaml
@@ -64,6 +64,9 @@ spec:
         storageClass: longhorn
         accessMode: ReadWriteOnce
         size: 1Gi
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /opt/app/backend/data
 

--- a/kubernetes/apps/default/readeck/app/helmrelease.yaml
+++ b/kubernetes/apps/default/readeck/app/helmrelease.yaml
@@ -96,6 +96,9 @@ spec:
         retain: true
         size: 10Gi
         storageClass: longhorn
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /readeck
 

--- a/kubernetes/apps/default/syncthing/app/helmrelease.yaml
+++ b/kubernetes/apps/default/syncthing/app/helmrelease.yaml
@@ -92,6 +92,9 @@ spec:
         size: 8Gi
         accessMode: ReadWriteOnce
         retain: true
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /var/syncthing/config
       data:

--- a/kubernetes/apps/home/home-assistant/app/pvc.yaml
+++ b/kubernetes/apps/home/home-assistant/app/pvc.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: home-assistant-config
+  labels:
+    recurring-job-group.longhorn.io/backup: enabled
+    recurring-job.longhorn.io/source: enabled
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: longhorn

--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -67,6 +67,9 @@ spec:
         storageClass: longhorn
         size: 1Gi
         retain: true
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /data
       config-file:

--- a/kubernetes/apps/media/bazarr/app/pvc.yaml
+++ b/kubernetes/apps/media/bazarr/app/pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: media
   labels:
     recurring-job-group.longhorn.io/backup: enabled
+    recurring-job.longhorn.io/source: enabled
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: longhorn

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -152,6 +152,9 @@ spec:
         storageClass: longhorn
         size: 40Gi
         retain: true
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /config
       movies:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -100,6 +100,9 @@ spec:
         storageClass: longhorn
         size: 500Mi
         retain: true
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /config
       downloads:

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -93,6 +93,7 @@ spec:
         size: 4Gi
         labels:
           recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
       downloads:
         enabled: true
         type: nfs

--- a/kubernetes/apps/media/seer/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seer/app/helmrelease.yaml
@@ -107,6 +107,9 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 4Gi
+        labels:
+          recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
         globalMounts:
           - path: /app/config
       config-cache:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -94,6 +94,7 @@ spec:
         size: 10Gi
         labels:
           recurring-job-group.longhorn.io/backup: enabled
+          recurring-job.longhorn.io/source: enabled
       downloads:
         enabled: true
         type: nfs


### PR DESCRIPTION
## Summary
- Add a weekly `ScheduledBackup` (`method: plugin`, Sun 05:00 UTC, `immediate: true`) per CNPG cluster — uses the existing `barman-cloud.cloudnative-pg.io` plugin + per-cluster `ObjectStore`, no new infra.
- First scheduled run seeds a base backup so `firstRecoverabilityPoint` populates, the existing WAL chain becomes restorable, and `CNPGLastBackupTooOld` clears.
- Steady-state PITR window settles to ~30d per cluster (bounded by the existing `retentionPolicy: "30d"` on each ObjectStore).