### PR TITLE
feat(affine): wire oidc to pocket-id

### DIFF
--- a/kubernetes/apps/default/affine/app/helmrelease.yaml
+++ b/kubernetes/apps/default/affine/app/helmrelease.yaml
@@ -40,6 +40,8 @@ spec:
               NODE_ENV: production
               # Server configuration
               PORT: &port "3010"
+              AFFINE_SERVER_EXTERNAL_URL: https://notes.${PUBLIC_DOMAIN}
+              AFFINE_SERVER_HTTPS: "true"
               AFFINE_INDEXER_ENABLED: false
               # Authentication
               OAUTH_EMAIL_LOGIN: "false"
@@ -114,3 +116,12 @@ spec:
         storageClass: longhorn
         globalMounts:
           - path: /data
+      config:
+        type: secret
+        name: affine-secret
+        advancedMounts:
+          affine:
+            app:
+              - path: /root/.affine/config/config.json
+                subPath: config.json
+                readOnly: true

--- a/kubernetes/apps/default/affine/app/secret.sops.yaml
+++ b/kubernetes/apps/default/affine/app/secret.sops.yaml
@@ -4,28 +4,29 @@ metadata:
     name: affine-secret
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:MfvFclY9YC0wO4jULyY=,iv:CnkUghWRuqM2/AHQSJjHmMK+dIbuFw+LMW1p/bEaykc=,tag:tQaFOzT6/wnevTeGEIHM6Q==,type:comment]
-    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:6O/s7Jgx,iv:0qNRCIjCzbGkPnzrn7fOZfMKnunObeDdA7fDQKLdmcU=,tag:WsIVr6tOXLlpKu05SC+pfA==,type:str]
-    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:47ySY8HdxNY1gKXVvo310w1euLGB/uLNsUMcnUu7esuepe4uaAGpYYRNZQ==,iv:iEkxIHQYxZbdBpxxpUSmvLV2UNiL2JJbXqx8+0G3h3w=,tag:xDmY1ZotAPq3R1yDH8O54A==,type:str]
-    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:TNZYhrxrKKAw/6okuDFJjQ==,iv:DYTOOy1t8JhB/9aXF32e5YuJh01devBYe6hSA6LC4cM=,tag:ekwKGe5oNfq0jEcsLfkFsg==,type:str]
-    INIT_POSTGRES_USER: ENC[AES256_GCM,data:3BGX5gAs,iv:CZZzmP3xOmGKrLYiYauBr5j4T0C5Pzvb0/013C/exD8=,tag:kaWZLegEvcht8tKanRyclg==,type:str]
-    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:RrSHRMSxIIznSqREPobT9kl2EWilwHee,iv:pnQFn8OxE8+N0vVHc4EJ0rEgczBXmr6HiLUBGZGVFL0=,tag:3Ub0wjtSXJf/EMG5qQJu+g==,type:str]
-    DATABASE_URL: ENC[AES256_GCM,data:vCSy+eVABAf1FKXtCeF+sqlXQzvAUUI5LwnKRYxRvnz3UxREw7t8Xz3mPNdkRhtExTg8RjaGL9HufgRYp0+oZoMkUSAhjWpM5mYVjmpdIfUo/wo7wKEfiJR9PekqOD0=,iv:HNFoDRghHCPWIITE4NbDuTNmgHDddqMRdupYAsvGPuY=,tag:bweXoQPnEtLqVHZMDnWSxQ==,type:str]
-    REDIS_SERVER_HOST: ENC[AES256_GCM,data:aJ6Lv8KPjc/tY5kjUpWTJfzGfBv2eQs9rEInGFC0tmSAkE2I1khKPA==,iv:Z2FWoFxzLnqcg+3/L1l1VPwov8PHwltyIL4PnE6T0H8=,tag:miLxFeZ70CJK6yoO4VP0cA==,type:str]
-    REDIS_SERVER_PORT: ENC[AES256_GCM,data:qJN0QQ==,iv:pAzBPyBwEozDuJSuPQPs1eYK7PekswUGs5wm1FoRUqM=,tag:paScwIBEj01llxHVL9DFXw==,type:str]
-    REDIS_SERVER_DATABASE: ENC[AES256_GCM,data:+Q==,iv:MqEZ7Y56A3sk4ZUnObT9DyiB1NUflGnWJ/O2Go+oYmI=,tag:ocbMXhamvtjXDXHpF7o5iQ==,type:str]
+    #ENC[AES256_GCM,data:B1HAlG69KPX6X51Al34=,iv:Z1CSxa+65i/CiWV3AqxmA7XOJAEhCnSkwewKMbCARSQ=,tag:p68Jf3v7ZMOhfb+slcuURA==,type:comment]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:76nYzxqN,iv:KfeYG2KN66a/vwxx05qJM72LUNEh3pjRWlyqewmsvMA=,tag:LV9dz2OCXhQCCE4k24clxg==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:vyo2bLT0BzLyFuAbLEAbztGw1QEeN+7JtIDtW2wYaTFJw/K6zgHo3o+EHw==,iv:+jT2LtVBnF/gVtiMK1O5apMoWjNqBMgxoKuSZklkmCE=,tag:vI1Y9BCGlm9Oi41MmaS8ag==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:cMuSh9j5TDcNcdkrnez4+g==,iv:YO7GgtM35UwEH15LGLvavi8t7RIctzGZI/4/KqKO02g=,tag:Cx7RIOrkTU56Yyh3dNxaVA==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:H7yPvg72,iv:OfmdH0k8dBRmIcnDDgO5i+ClUW0Jxc9KxQFTy1u+YQc=,tag:4eaIWMynokGkovBNfECGRg==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:uqw5GUF2EKQ8m2fUGW/RJrDI3uP041M5,iv:h7lrG71YAMZEITHZl+StTp9er5ceEi9lSjLh+j/BKZ8=,tag:du7NJUzXAIGNl8zjnF7WeA==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:wDDpy80tw/vou/lG6iOGYije2iR9KrSx5LPYGh0/BcKPEam+Pcm4uauw37bNYhC7ih9oCbx2tMfXwL9rsJiwW6ypVZIxLXBNgkVgaqltwDD/i1yfS9rF0N2szYUaRcc=,iv:OgV2Do4OCXaQuX1yOx8VDeNazf+dZM3I/cio4IlaMmo=,tag:RWPenohULyDWi8FGh+f/OA==,type:str]
+    REDIS_SERVER_HOST: ENC[AES256_GCM,data:wNWzzQWZlxh4ezTjj4KKw4wI/64EEy6L5YfRVVdnUVcM/S/mxijAKw==,iv:7zx3CO2WSgZh5CYf91FQbhGKBjJS8p68trj+G7u4wEs=,tag:Q2bKU/gfR11CIlCyjaCReA==,type:str]
+    REDIS_SERVER_PORT: ENC[AES256_GCM,data:tSWmAg==,iv:AnXomqnJAP1NENRl4ISpQ3h1uVP2OK41Cp+198cqH1U=,tag:wezafBZM6H7s8pplzKy1mw==,type:str]
+    REDIS_SERVER_DATABASE: ENC[AES256_GCM,data:eg==,iv:wFoMhDJhhd9gIpsivZX+QymuzD2vKu112RXq1cXgafE=,tag:0vkMW9csKcXEMjO3Pmhdww==,type:str]
+    config.json: ENC[AES256_GCM,data:3k2VtIJjywkn+Yrp0w7rhlqhC314qAawGsW0YiTBdGR5DPZbviJJpQhUnt5XIckA0T0WQHFSdDu314thWL/Ga2TcljL3suWFv2O1pumwzrZkYb0Tlz2SHfDMkL9GXFPCI8TSB3ZodBS4rk0M2xcHTUBv8mRmTRcLuh2yzYMwJWwAMLVwocUDDihrh0bcIcaZDIZdse6/crh2x8qCE2EA9ql8lUQEYb1KbMMO5HFNtE+9tYJjj5xA1QOgzCp0YV8XPfytycXa4n1Cqgc/BFgsRDgeswx9pB6ZrF3kEBCpp7fFvr7cdqdz/hsFBvrOJwoSMLKa/KIxufEq9MwBKx2Dxi0MHF4xO4IsyM97t4GxopLHtoOXszMpXl6g81aRoZmN89CyTswf69lrkB5Jh9hg7TQM07PLql7ODNMr7xxWmz9o3jv2GUmbUeVE2uibMoodumAtKpsFGJVksBDr31Tov0p8h8MxFTDk4juz7p0=,iv:z67xFosBLq8GlIdulyzI1aM8508cdOG4SCYPztgExpw=,tag:R/yEDxAbLmAC6hG1K0L1Hw==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCVTlROW9mS0dBZkJ1UUFW
-            Z204aGdrYkUzenVXV25MY0F3OENiSUdVUG5BCmVJNEFmUzFMNnJtOVRLWlNaMmxC
-            aGlFbmlUaVQrQjArTlhOTGE5em9FcG8KLS0tIFErbzN3cTNYTFBobEtqYmZ0WXQ5
-            d1NYM3d4eDdaTHVNbnlhTzl1eVlPZE0K9YrQ6+on4WjMM6Nmop7kNHktbC6ZH+yx
-            pgPTjOyK9FTizhgUafUWWu55P0qwpd4zCCYop/AuRh4niuj9Xpe6JA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRU0VYNk9jUEhMMk5iT3Fx
+            bytiMmJSbkRlZ3F5UGZjVjNhR2paRFFNOWdnCnM2d2M0cFVsekFYenFSbXRBdWQv
+            THRUVzF2bXVYaVNaSGlnckRMalZrdUEKLS0tIEFLYnd1M3BzdThoMlp2VzViTzNV
+            YUJaSk5mR0V3ZFEwcGhsaHdCRU5LUmMKNRF6p5983oVnCkJgh34YW5Y3HmXGYedz
+            irkB8NPB/l08IC+ub8pj3SXNsBDfE8QorFxEq8+6/MWH48d5v4Y+9g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-15T09:10:20Z"
-    mac: ENC[AES256_GCM,data:Ex6cn0hQh/NxUfs3e2rFrKLqmiWBvBkS4Q/VDrE2MaKYFdod3n8UlOVI+FayQkl5gC0EXagCBVqiBj4BBrF6Qj1Ekb15cwQkHaIKG0MwYeH4yLBzNHbqs/OeZPJvPoVDp1/CUZfI3cXQgi7sDqcAmEg+Le1y+7tLrnv7Rjg/x+I=,iv:FT1YnnZoNq4IFmarKd155cwGTgDStJVNMd+DRrsjLdM=,tag:U3PeOKryAGeRfkyGG+ZXLA==,type:str]
+    lastmodified: "2026-05-17T12:38:19Z"
+    mac: ENC[AES256_GCM,data:Uq1tTCYQUjFN7RXvFC0tfviZCBBUiioPTxZ0nsex+E0Uu1gn92H5TvWF0mieZdKjIoNXx6438TQ1CfyOWebdYusKnN13idF7g+6HPo7laJdt0qqVosJxMgxRjNgBlXobjOITYhCaCrtgYGy2pKkzznDyYBwQF32/j6zgBkxfFdo=,iv:4B6TI+bzcpkzWWytwJlPT3FEHCus4/hzvQw6q23dvX8=,tag:PKaJsK7znoD/PwGxmKfHAw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary

- Mount `affine-secret`'s new `config.json` key at `/root/.affine/config/config.json` to bootstrap Affine's OIDC provider (issuer, clientId, clientSecret) plus `server.hosts` for the LAN hostname.
- Set `AFFINE_SERVER_EXTERNAL_URL` and `AFFINE_SERVER_HTTPS` so Affine sends the correct `redirect_uri` to pocket-id from either gateway.
- Existing user is auto-linked on first OIDC login via `models.user.fulfill(email, ...)` — no manual migration needed as long as pocket-id reports the same email.