### PR TITLE
feat(affine): block /admin on external route

### DIFF
--- a/kubernetes/apps/default/affine/app/helmrelease.yaml
+++ b/kubernetes/apps/default/affine/app/helmrelease.yaml
@@ -104,6 +104,10 @@ spec:
             sectionName: https
         hostnames: ["notes.${PUBLIC_DOMAIN}"]
         rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /admin
           - backendRefs:
               - identifier: app
                 port: http


### PR DESCRIPTION
## Summary

- Add a `PathPrefix: /admin` rule with no backend on the external HTTPRoute so `notes.${PUBLIC_DOMAIN}/admin*` returns 404 instead of reaching Affine.
- Internal route on `notes.${SECRET_DOMAIN}` is unchanged — admin panel remains reachable from LAN.