### PR TITLE
feat(versitygw): default WebUI endpoints and split admin onto LAN-only host

### DIFF
--- a/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
@@ -56,6 +56,9 @@ spec:
               TZ: "${TIMEZONE:=Etc/UTC}"
               VGW_PORT: ":7070"
               VGW_REGION: us-east-1
+              VGW_WEBUI_GATEWAYS: "https://s3.${SECRET_DOMAIN}"
+              VGW_WEBUI_ADMIN_GATEWAYS: "https://s3.${SECRET_DOMAIN}"
+              VGW_CORS_ALLOW_ORIGIN: "https://s3-console.${SECRET_DOMAIN}"
             envFrom:
               - secretRef:
                   name: versitygw-secret
@@ -105,7 +108,7 @@ spec:
           - name: internal
             namespace: networking
             sectionName: https
-        hostnames: ["versitygw.${SECRET_DOMAIN}"]
+        hostnames: ["s3-console.${SECRET_DOMAIN}"]
         rules:
           - backendRefs:
               - identifier: app

--- a/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/versitygw/app/helmrelease.yaml
@@ -55,9 +55,10 @@ spec:
             env:
               TZ: "${TIMEZONE:=Etc/UTC}"
               VGW_PORT: ":7070"
+              VGW_ADMIN_PORT: ":7072"
               VGW_REGION: us-east-1
               VGW_WEBUI_GATEWAYS: "https://s3.${SECRET_DOMAIN}"
-              VGW_WEBUI_ADMIN_GATEWAYS: "https://s3.${SECRET_DOMAIN}"
+              VGW_WEBUI_ADMIN_GATEWAYS: "https://s3-admin.${SECRET_DOMAIN}"
               VGW_CORS_ALLOW_ORIGIN: "https://s3-console.${SECRET_DOMAIN}"
             envFrom:
               - secretRef:
@@ -102,6 +103,8 @@ spec:
             port: *port
           webui:
             port: 7071
+          admin:
+            port: 7072
     route:
       webui:
         parentRefs:
@@ -123,6 +126,16 @@ spec:
           - backendRefs:
               - identifier: app
                 port: s3
+      admin:
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["s3-admin.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: admin
     persistence:
       data:
         accessMode: ReadWriteOnce


### PR DESCRIPTION
## Summary
- Set `VGW_WEBUI_GATEWAYS`, `VGW_WEBUI_ADMIN_GATEWAYS`, `VGW_CORS_ALLOW_ORIGIN` so the WebUI defaults to the public S3/admin hosts and accepts the console origin
- Rename WebUI hostname `versitygw.${SECRET_DOMAIN}` → `s3-console.${SECRET_DOMAIN}` to match the `s3` / `s3-console` sibling-subdomain pattern
- Split admin onto its own port (`VGW_ADMIN_PORT=:7072`) behind a LAN-only `s3-admin.${SECRET_DOMAIN}` route so future external `s3` exposure cannot leak admin