### PR TITLE
feat(default): add hoodik e2e file storage on cnpg-default + versitygw

### DIFF
--- a/ansible/playbooks/openwrt-router.yml
+++ b/ansible/playbooks/openwrt-router.yml
@@ -45,6 +45,7 @@
     public_lan_subdomains:
       - analytics
       - auth
+      - drive
       - media
       - photos
       - portfolio

--- a/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
@@ -16,6 +16,12 @@ spec:
     initdb:
       database: hass
       owner: hass
+  managed:
+    roles:
+      - name: hoodik
+        login: true
+        passwordSecret:
+          name: cnpg-default-hoodik
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/databases/cnpg-default/app/database-hoodik.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/database-hoodik.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: hoodik
+  namespace: databases
+spec:
+  name: hoodik
+  owner: hoodik
+  cluster:
+    name: cnpg-default

--- a/kubernetes/apps/databases/cnpg-default/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/kustomization.yaml
@@ -3,8 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./database-hoodik.yaml
   - ./objectstore.yaml
   - ./podmonitor.yaml
   - ./prometheusrule.yaml
+  - ./role-hoodik.sops.yaml
   - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-default/app/role-hoodik.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/role-hoodik.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cnpg-default-hoodik
+    namespace: databases
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:m9jaqlQ5,iv:9ZWChIaP0nlQrz4UsO5KwSqFJdifu/cBp+LO6orx7og=,tag:TfPYzzCkAG3RG9WxSS95mw==,type:str]
+    password: ENC[AES256_GCM,data:NrWZ5gtdtLeMG39dtsPDg0iMyEoOKhVDoSNsNjFhBTLLseZisdtTCw==,iv:tVJXAedoc40O+23p5w+VfLC9nh9j+iR3cVSYcSNDbMQ=,tag:+7HQVVwI43zDmmhzLI13gw==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvbFpESVljWTg4SExpOFFn
+            aHRuU1puNTRxb3pGenhMYkZuVDZtRVJDL0FJCjJXeGtiOUgyQ2FyeTZRWG5STXFN
+            V1NwbzRNWGxETFZnOEowdmZXeTI1QmcKLS0tIDdPcDRNTitxUExqOFY2M2Z0NjRU
+            M0FJcTR5U1VyN3EyQXVqT2JLdytVaGcK8yv4KK2Ose/CugnlWM+fQmFwAftef/gl
+            xyW7MjxEeUn/3CcxJDB8NGTVJoNB/lLGt+oxwlKCpjYdK6icM6ZU3A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-17T15:51:14Z"
+    mac: ENC[AES256_GCM,data:40KA6t31h+/Kavx+QlFkIJVQVPRWq/w5N51E0fimFF32t5DjGTt/Dkcbe8d5LkcTY1IP5PW8e9Mk55Zh9D6aRJWhBen9HYE1esUuBDR67Hq3BUKIuMA1jt0MUWEoUlszdPi6w5R4bVTTTjdSQrt6lKdEWUL+Ldo904ajb/bgDaM=,iv:w2pF03ax5H4cp7VLLKELbLvsawD6nMPFqteQjGjn+zU=,tag:qE6M3qrE/Pduc81iKWYeVQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/default/hoodik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hoodik/app/helmrelease.yaml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hoodik
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  driftDetection:
+    mode: enabled
+
+  values:
+    controllers:
+      hoodik:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          app:
+            image:
+              repository: docker.io/hudik/hoodik
+              tag: v1.15.3@sha256:e703d7cf9e6ac3abc8c0182c37c46debe1bd12d4dcb7b657c3a0a6206760f8f8
+            env:
+              TZ: ${TIMEZONE}
+              DATA_DIR: /data
+              APP_URL: https://drive.${PUBLIC_DOMAIN}
+              APP_NAME: Hoodik
+              HTTP_ADDRESS: 0.0.0.0
+              HTTP_PORT: &port 5443
+              SSL_DISABLED: "true"
+              STORAGE_PROVIDER: s3
+              S3_BUCKET: hoodik
+              S3_REGION: us-east-1
+              S3_ENDPOINT: http://versitygw.storage.svc.cluster.local:7070
+              S3_PATH_STYLE: "true"
+            envFrom:
+              - secretRef:
+                  name: hoodik-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/liveness
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+
+    service:
+      app:
+        controller: hoodik
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Hoodik
+          gethomepage.dev/group: Productivity
+          gethomepage.dev/icon: hoodik.png
+          gethomepage.dev/description: End-to-end encrypted file storage
+        parentRefs:
+          - name: external
+            namespace: networking
+            sectionName: https
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames:
+          - "drive.${PUBLIC_DOMAIN}"
+          - "drive.${SECRET_DOMAIN}"
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        retain: true
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/default/hoodik/app/kustomization.yaml
+++ b/kubernetes/apps/default/hoodik/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/default/hoodik/app/secret.sops.yaml
+++ b/kubernetes/apps/default/hoodik/app/secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hoodik-secret
+    namespace: default
+type: Opaque
+stringData:
+    DATABASE_URL: ENC[AES256_GCM,data:TVwM0wAvLVUJ8vMqaIdUU0y2ccyiHwkhPTQ7wDLli7z+pXaPyD6vrIen4p/aETsuWufqI00QswaAmCVerDUOq0BkYzaitBx2Uw/eJ7kx/YT1k63Wfv5qOLVm2vd/pTSeAUt99AXKR+oedj9rlNJsiTf2,iv:9dmc8ckaFXilV6gIjZ2KQuD5QNbwNfjhN89D81Yfcyc=,tag:s0J0SoT0PqmQFEJlyULJGA==,type:str]
+    S3_ACCESS_KEY: ENC[AES256_GCM,data:Ak6VP2DZ,iv:yVNbWatatkAZUKmbBONwOTFDqjSWrD32gIZ+USiwUKA=,tag:xFpdBTWTrrBLHjysRQq21Q==,type:str]
+    S3_SECRET_KEY: ENC[AES256_GCM,data:nZTLMXf9iuOc9Gyt2NSaNPZOj6taTGr/+GhD07nSi+MeAB6TQ/7gnw==,iv:GexhmKTOnOl9UgPWSNJAKvnzeSh/YfUu2FfYd8PAm6E=,tag:zIiawTUAGsZKn0lYKofH7A==,type:str]
+    JWT_SECRET: ENC[AES256_GCM,data:t/vqRwx9F+m/JSFSnRrz60amgejBHtFmKirHGRFUjimAb0IiTStC/VlOm4KYXc5ZSAVqHCJikoM21r+9gHg=,iv:XrqKn/Af1Clxn/XVlE896jbcExCwRfs65WlBe79XbQ4=,tag:uEP4BQirRALcKdgIt1Rn+g==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCWWVHbC9ram1lbDVWYWd1
+            TmdocGI5T0JBNnUwNEQzdGJZNU5tN29ydENVCmM5NmlqVDZpbzE3eFRPL2ZlWTl4
+            Wit1YWNuTG5iTkdVejhtQ3h5c2NxalkKLS0tIE9hbC94QTkwdWl2bkx0dnl5Qk9h
+            VEw0R1cvTXZVKzVSSTVMTHJFMXp3ZTAK0Aud+/BY5ia5hYgBdB5PSdWWKMUojPtE
+            WRvNz+2ttjj/QoDrLSXor8mptwX9nTW//qCU4dGT3oEMqJnG4935TQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-17T15:58:24Z"
+    mac: ENC[AES256_GCM,data:EsJYMQvm/D1sFws/F2f1N5XUzoAnKpv9zQ2h6IKc2JLUFQDp6+rxtb28OsPPBo7Xg1YXB58ae0UgKLkWO0RZMDz6f3o7XK1RJQRZtOBw+Ydf5373b24KmT7uYtR7S2EyeP7de/0W0q/e95TMr544e94Netl1kBhCsiAqlaTeEoU=,iv:/u3iQ0jWjr4RIDWQYCd4UAOAf0GLZ5KiBz4+iLU7jMg=,tag:AxBSMaDBGftqbgWzXD5byw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/default/hoodik/ks.yaml
+++ b/kubernetes/apps/default/hoodik/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hoodik
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cnpg-default
+      namespace: flux-system
+  path: ./kubernetes/apps/default/hoodik/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./distcc/ks.yaml
   - ./echo-server/ks.yaml
   - ./homepage/ks.yaml
+  - ./hoodik/ks.yaml
   - ./immich/ks.yaml
   - ./n8n/ks.yaml
   - ./ocis/ks.yaml


### PR DESCRIPTION
## Summary

- Deploys hoodik (e2e-encrypted file storage) under `default` ns, app-template v5, exposed at `drive.${PUBLIC_DOMAIN}` via external + internal Cilium Gateway with LAN DNS override.
- Provisions a managed `hoodik` postgres role + `Database` on the existing `cnpg-default` cluster (declarative — no manual psql).
- Stores chunks on Versity (`s3://hoodik` via `versitygw.storage.svc.cluster.local:7070`); `/data` PVC keeps only TLS material + local state.