### PR TITLE
feat(cnpg): tighten WAL retention and cap slot WAL keep size

### DIFF
--- a/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
@@ -18,6 +18,11 @@ spec:
       owner: pocketid
       secret:
         name: pocketid-credentials
+  postgresql:
+    parameters:
+      wal_keep_size: "128MB"
+      max_wal_size: "512MB"
+      max_slot_wal_keep_size: "512MB"
   affinity:
     enablePodAntiAffinity: true
     podAntiAffinityType: required

--- a/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/cluster.yaml
@@ -16,6 +16,11 @@ spec:
     initdb:
       database: hass
       owner: hass
+  postgresql:
+    parameters:
+      wal_keep_size: "128MB"
+      max_wal_size: "512MB"
+      max_slot_wal_keep_size: "512MB"
   managed:
     roles:
       - name: hoodik

--- a/kubernetes/apps/databases/cnpg-immich/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/cluster.yaml
@@ -15,6 +15,10 @@ spec:
   postgresql:
     shared_preload_libraries:
       - vchord.so
+    parameters:
+      wal_keep_size: "128MB"
+      max_wal_size: "512MB"
+      max_slot_wal_keep_size: "512MB"
   bootstrap:
     initdb:
       database: immich

--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -16,6 +16,11 @@ spec:
     initdb:
       database: seer
       owner: seer
+  postgresql:
+    parameters:
+      wal_keep_size: "128MB"
+      max_wal_size: "512MB"
+      max_slot_wal_keep_size: "512MB"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

- Set `wal_keep_size=128MB`, `max_wal_size=512MB`, `max_slot_wal_keep_size=512MB` on all four CNPG clusters (`cnpg-default`, `cnpg-auth`, `cnpg-media`, `cnpg-immich`).
- Caps the previously-unbounded `max_slot_wal_keep_size` — the setting that let an offline replica's slot pin WAL indefinitely on cnpg-auth-2 and ENOSPC'd its PVC during pg_rewind.
- Shrinks the WAL footprint floor from ~577 MiB to ~150 MiB per cluster; reduces snapshot-diff churn as a side effect.