### PR TITLE
feat(media): add dispatcharr iptv proxy on cnpg-media

### DIFF
--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -21,6 +21,12 @@ spec:
       wal_keep_size: "128MB"
       max_wal_size: "512MB"
       max_slot_wal_keep_size: "512MB"
+  managed:
+    roles:
+      - name: dispatcharr
+        login: true
+        passwordSecret:
+          name: cnpg-media-dispatcharr
   resources:
     requests:
       cpu: 50m

--- a/kubernetes/apps/databases/cnpg-media/app/database-dispatcharr.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/database-dispatcharr.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: dispatcharr
+  namespace: databases
+spec:
+  name: dispatcharr
+  owner: dispatcharr
+  cluster:
+    name: cnpg-media

--- a/kubernetes/apps/databases/cnpg-media/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/kustomization.yaml
@@ -3,7 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./database-dispatcharr.yaml
   - ./objectstore.yaml
   - ./podmonitor.yaml
+  - ./role-dispatcharr.sops.yaml
   - ./scheduledbackup.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/cnpg-media/app/role-dispatcharr.sops.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/role-dispatcharr.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cnpg-media-dispatcharr
+    namespace: databases
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:fdxLfj9t23qpAgQ=,iv:d5GAifZ/u4lPDzSCeAIpAs62DeRyG0qLqbfM9iGjK9k=,tag:OfHNhyrnyMlAyfnbIG9WyA==,type:str]
+    password: ENC[AES256_GCM,data:UDysDvlVrfMy1a/mhtb+K89lRRmPSlohgkLGZX19+2Q=,iv:KoDgfF+sBFflR55/g1057qFq2Eb/XDOf5R8sOd13z90=,tag:aYyvXYbf13xqTqRnMtK28w==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzeXAwYW5LTVp6NWNIcCt2
+            TWRzUzBkTmdncGNSWEc3NjI1ZVV3bmt2aFJVCjdhRGJBKzVUMVA2MTVZczl1b1k0
+            eEFzT0s5Sm00dWxEbDJFY3FJc0NpSjQKLS0tIHNHaWE2SjI1bjB1Y3IvNmF3a2F6
+            Rm1TT3Yvck5JZkh1RktLWE1rQTYzdG8KxkHywgp4OHG9uGgQufL8t92BtnHcf4dE
+            6ryvpnaaFAIsVWZqlLqPV4g5i8HNnPWrM6LY6s5tTWmqKfda/0yLUQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-17T07:46:15Z"
+    mac: ENC[AES256_GCM,data:lsiiEg4O2F3zt5RKEQg01Ngr3I1o0IjTi7hFUjixnoOS65eLfXBL8QmEuWzZY9QfyV/GerBGOsmKJvkJokQJyDhb66Guj4Ytbk20RxrGIdPDKkBHiVg3hFnnNwElYIrKob5ZzvWfMgmIqgReI5NVziy+b4VfOqhBqh7KYlUUBoc=,iv:CyVSObmRZ6T6WscX80WQ8rRFQWwDTrVOGRwH8NdawR0=,tag:WNcjMGRLja0RP3hisFUyTg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name dispatcharr
+  namespace: media
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: *name
+    controllers:
+      dispatcharr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dispatcharr/dispatcharr
+              tag: 0.27.0@sha256:425129020764037869c7d1a2e74ba57ca640cb5d551ef57d869b745b6ea71c7b
+            env:
+              TZ: ${TIMEZONE}
+              DISPATCHARR_ENV: modular
+              DISPATCHARR_LOG_LEVEL: info
+              DISPATCHARR_PORT: &port 9191
+              POSTGRES_HOST: cnpg-media-rw.databases.svc.cluster.local
+              POSTGRES_PORT: "5432"
+              POSTGRES_DB: dispatcharr
+              REDIS_HOST: redis-master.databases.svc.cluster.local
+              REDIS_PORT: "6379"
+              CELERY_BROKER_URL: redis://redis-master.databases.svc.cluster.local:6379/0
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: cnpg-media-dispatcharr
+                    key: username
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: cnpg-media-dispatcharr
+                    key: password
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    service:
+      app:
+        controller: *name
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Dispatcharr
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: dispatcharr.png
+        parentRefs:
+          - name: internal
+            namespace: networking
+            sectionName: https
+        hostnames: ["dispatcharr.${SECRET_DOMAIN}"]
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+    persistence:
+      config:
+        existingClaim: *name
+        advancedMounts:
+          dispatcharr:
+            app:
+              - path: /data
+                subPath: data
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          dispatcharr:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/dispatcharr/app/pvc.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dispatcharr
+  namespace: media
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job-group.longhorn.io/backup: enabled
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/media/dispatcharr/ks.yaml
+++ b/kubernetes/apps/media/dispatcharr/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dispatcharr
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-cnpg-media
+  path: ./kubernetes/apps/media/dispatcharr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./bazarr/ks.yaml
+  - ./dispatcharr/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./jellyfin/ks.yaml
   - ./seer/ks.yaml


### PR DESCRIPTION
## Summary

- New `dispatcharr` app in the `media` namespace (ghcr.io/dispatcharr/dispatcharr `0.27.0`) routed at `dispatcharr.${SECRET_DOMAIN}` on the internal gateway
- Runs in `DISPATCHARR_ENV: modular` against the shared `cnpg-media` Postgres cluster and the shared `redis-master` service in `databases`
- Provisions the DB declaratively via a `Database` CR + `Cluster.spec.managed.roles[]` + SOPS basic-auth Secret (`cnpg-media-dispatcharr`), mirroring the `cnpg-default`/`hoodik` pattern