### PR TITLE
fix(media): provide dispatcharr postgres creds in media namespace

### DIFF
--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -39,16 +39,9 @@ spec:
               REDIS_HOST: redis-master.databases.svc.cluster.local
               REDIS_PORT: "6379"
               CELERY_BROKER_URL: redis://redis-master.databases.svc.cluster.local:6379/0
-              POSTGRES_USER:
-                valueFrom:
-                  secretKeyRef:
-                    name: cnpg-media-dispatcharr
-                    key: username
-              POSTGRES_PASSWORD:
-                valueFrom:
-                  secretKeyRef:
-                    name: cnpg-media-dispatcharr
-                    key: password
+            envFrom:
+              - secretRef:
+                  name: dispatcharr-secret
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./pvc.yaml
+  - ./secret.sops.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/dispatcharr/app/secret.sops.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: dispatcharr-secret
+    namespace: media
+type: Opaque
+stringData:
+    POSTGRES_USER: ENC[AES256_GCM,data:RBeNS4lqd1JuUgI=,iv:gXPml6Y8EECTw4mF9qc1WfRu6aAsWkmVn/E279JpL+A=,tag:+Hr9k10n/FVeT4C7kU4AeQ==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:e9A2QpwSrgBx0KpdkouM1vsdpa0fKNiVBLWad10SyGY=,iv:Ipjc0fH9gy8nURJPddOJ5AdVGineqIy0l3xDUPIcMLk=,tag:hMt/MxSE2bAyIt+7WFUOzQ==,type:str]
+sops:
+    age:
+        - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxQ09JemEzbFBOOXUwU2U0
+            cjVnT0NwRGdMNEF4OGRrK0xhVVEyd3gyRDM4ClBDYXIyV0FCUUtWWnZFeDVMblZR
+            OFRleFFxMU1rR1A4Q1VoN2RxRitNdzgKLS0tIFVEZS8ycGhmWTk3alN0WFBQL20w
+            VHAvKyt5anZ1dVhTaWJVd3YxOXVYUmcK8kGuQtzSK+IPFWH5/RX8LP/FAHwf9Pv/
+            ZnaA+lByyLDK2ueQLlxWCfYTWXZRgc8yNalsUkZHhXBy9g/5BTaFpQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-17T08:00:30Z"
+    mac: ENC[AES256_GCM,data:gEgqQ7SP6mmpd2x9NV+fNwQVl/J+GAlYwK7L2tdIkWvPSKz2uOUyiGg5EfI/7F+9S7gryLaa4/vL/bIuBPteLoymuGz6sSFWD6dcPbn9qR/cqpRTf00N3g/49XsURSpdaInXe5xae+m0RzxnYQjkDaChYt2sgvPMBPP/szH0KeU=,iv:/O9/t9RKmWLCkBfcNVSfiP7qczXEpEWLtThr34c71zo=,tag:0/mbRUpa39mH0NM65gJ+Hg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
## Summary

- Follow-up to #2768: the dispatcharr pod hit `CreateContainerConfigError: secret "cnpg-media-dispatcharr" not found` because that Secret lives in `databases` (where CNPG creates it from the managed role) and Kubernetes `secretKeyRef` is namespace-local
- Adds a SOPS-encrypted `dispatcharr-secret` in `media` with the same `POSTGRES_USER` / `POSTGRES_PASSWORD`, and switches the helmrelease to `envFrom` it (same pattern sonarr uses for its DB creds)
- The `cnpg-media-dispatcharr` basic-auth Secret in `databases` stays — CNPG still uses it to provision the role