### PR TITLE
refactor(dispatcharr): drop inert sqlite mode and pin VPN skip

### DIFF
--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -22,20 +22,14 @@ spec:
     defaultPodOptions:
       nodeSelector:
         kubernetes.io/arch: amd64
+      labels:
+        setGateway: "false"
+      annotations:
+        setGateway: "false"
     controllers:
       dispatcharr:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          sqlite-wal-init:
-            image:
-              repository: ghcr.io/dispatcharr/dispatcharr
-              tag: 0.27.0@sha256:425129020764037869c7d1a2e74ba57ca640cb5d551ef57d869b745b6ea71c7b
-            command: ["/bin/sh", "-c"]
-            args:
-              - >-
-                mkdir -p /data &&
-                python3 -c 'import sqlite3; c=sqlite3.connect("/data/dispatcharr.db"); c.execute("PRAGMA journal_mode=WAL"); c.execute("PRAGMA synchronous=NORMAL"); c.close()'
         containers:
           app:
             image:
@@ -46,13 +40,12 @@ spec:
               DISPATCHARR_ENV: aio
               DISPATCHARR_LOG_LEVEL: info
               DISPATCHARR_PORT: &port 9191
-              DB_ENGINE: sqlite
             resources:
               requests:
                 cpu: 50m
                 memory: 512Mi
               limits:
-                memory: 2Gi
+                memory: 4Gi
     service:
       app:
         controller: *name
@@ -80,9 +73,6 @@ spec:
         existingClaim: *name
         advancedMounts:
           dispatcharr:
-            sqlite-wal-init:
-              - path: /data
-                subPath: data
             app:
               - path: /data
                 subPath: data


### PR DESCRIPTION
## Summary
- Remove `DB_ENGINE=sqlite` env + `sqlite-wal-init` initContainer + its advancedMount — never engaged because the image entrypoint runs migrate/uwsgi via `su - dispatch -c …` which strips env. Dispatcharr has been running on the internal AIO Postgres the whole time.
- Pin `setGateway: "false"` via `defaultPodOptions.labels`/`annotations` so the pod-gateway webhook permanently skips VPN injection (IPTV provider 401s on VPN exit IPs).
- Bump memory limit `2Gi → 4Gi` to match what's been needed in practice — AIO mode bundles internal pg + redis + uwsgi + celery in one container.