### PR TITLE
refactor(loki): collapse to SingleBinary mode with embedded caches

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    deploymentMode: SimpleScalable
+    deploymentMode: SingleBinary
 
     loki:
       auth_enabled: false
@@ -46,7 +46,7 @@ spec:
         chunk_encoding: snappy
 
       commonConfig:
-        replication_factor: 2
+        replication_factor: 1
 
       limits_config:
         ingestion_burst_size_mb: 128
@@ -100,8 +100,22 @@ spec:
           s3ForcePathStyle: true
           insecure: false
 
+      structuredConfig:
+        chunk_store_config:
+          chunk_cache_config:
+            embedded_cache:
+              enabled: true
+              max_size_mb: 512
+              ttl: 1h
+        query_range:
+          results_cache:
+            cache:
+              embedded_cache:
+                enabled: true
+                max_size_mb: 128
+
     gateway:
-      replicas: 2
+      replicas: 1
       enabled: true
       image:
         registry: ghcr.io
@@ -141,20 +155,33 @@ spec:
       ingress:
         enabled: false
 
+    singleBinary:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
+        limits:
+          memory: 2Gi
+      persistence:
+        enabled: true
+        storageClass: longhorn
+        size: 20Gi
+
     read:
-      replicas: 3
+      replicas: 0
 
     write:
-      replicas: 3
-      persistence:
-        storageClass: longhorn
-        size: 20Gi
+      replicas: 0
 
     backend:
-      replicas: 3
-      persistence:
-        storageClass: longhorn
-        size: 20Gi
+      replicas: 0
+
+    chunksCache:
+      enabled: false
+
+    resultsCache:
+      enabled: false
 
     monitoring:
       dashboards:
@@ -163,7 +190,7 @@ spec:
       rules:
         enabled: false
       serviceMonitor:
-        enabled: false
+        enabled: true
         metricsInstance:
           enabled: false
       selfMonitoring:


### PR DESCRIPTION
## Summary

- Switch loki to `deploymentMode: SingleBinary`, dropping the external 8 GB chunks-cache and 1 GB results-cache memcached StatefulSets in favour of in-process 512 MiB / 128 MiB embedded caches
- Frees ~9 GiB of memory pressure on cn5/cn8; Loki pod count goes from ~13 to 2 (`loki-0` STS + 1 `loki-gateway`)
- Same S3 backend (versitygw), same 14d retention, same LogQL — HTTPRoute and Alloy ingestion path unchanged