### PR TITLE
fix(vpn-gateway): persist dnsmasq leases to prevent DHCP pool exhaustion

### DIFF
--- a/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
@@ -84,3 +84,15 @@ spec:
       gatewayAnnotation: setGateway
       namespaceSelector:
         label: "vpn-routed-gateway"
+
+    persistence:
+      dnsmasq-leases:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 32Mi
+        advancedMounts:
+          main:
+            main:
+              - path: /var/lib/misc


### PR DESCRIPTION
## Summary

- Mount a 32Mi longhorn PVC at \`/var/lib/misc\` in the gateway pod so dnsmasq's \`dnsmasq.leases\` file survives pod restarts
- Root cause: pool exhaustion from 45h of accumulated phantom leases — dnsmasq had no persistent storage so couldn't reclaim expired IPs across restarts; prowlarr (88+ crash-loop restarts) and bazarr sidecars could no longer obtain a DHCP lease from the \`172.16.0.20–172.16.0.255\` range
- Helm upgrade triggers a gateway pod restart which resets the lease table from the new (empty) PVC, immediately unblocking prowlarr and bazarr