### PR TITLE
feat(auth): configure pocket-id smtp relay

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -46,6 +46,11 @@ spec:
               ANALYTICS_DISABLED: "true"
               PORT: &port 1411
               TZ: ${TIMEZONE}
+              UI_CONFIG_DISABLED: "true"
+              SMTP_HOST: smtp-relay.networking.svc.cluster.local
+              SMTP_PORT: "25"
+              SMTP_FROM: noreply@mail.thiagoalmeida.xyz
+              SMTP_TLS: none
             envFrom:
               - secretRef:
                   name: pocket-id-secret


### PR DESCRIPTION
## Summary

- Wire Pocket-ID to the in-cluster smtp-relay (`smtp-relay.networking.svc.cluster.local:25`)
- Set `UI_CONFIG_DISABLED=true` to prevent the UI from overriding env-based SMTP config
- Sender address: `noreply@mail.thiagoalmeida.xyz`