### PR TITLE
feat(default): configure hoodik smtp relay

### DIFF
--- a/kubernetes/apps/default/hoodik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hoodik/app/helmrelease.yaml
@@ -47,6 +47,11 @@ spec:
               HTTP_ADDRESS: 0.0.0.0
               HTTP_PORT: &port 5443
               SSL_DISABLED: "true"
+              MAILER_TYPE: smtp
+              SMTP_ADDRESS: smtp-relay.networking.svc.cluster.local
+              SMTP_PORT: "25"
+              SMTP_TLS_MODE: none
+              SMTP_DEFAULT_FROM_EMAIL: noreply@mail.thiagoalmeida.xyz
               STORAGE_PROVIDER: s3
               S3_BUCKET: hoodik
               S3_REGION: us-east-1


### PR DESCRIPTION
## Summary

- Wire Hoodik to the in-cluster smtp-relay (`smtp-relay.networking.svc.cluster.local:25`)
- Enable `MAILER_TYPE=smtp` for email confirmation on registration
- Sender address: `noreply@mail.thiagoalmeida.xyz`