### PR TITLE
fix(default): add smtp credentials placeholders for hoodik relay

### DIFF
--- a/kubernetes/apps/default/hoodik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hoodik/app/helmrelease.yaml
@@ -52,6 +52,8 @@ spec:
               SMTP_PORT: "25"
               SMTP_TLS_MODE: none
               SMTP_DEFAULT_FROM_EMAIL: noreply@mail.thiagoalmeida.xyz
+              SMTP_USERNAME: relay
+              SMTP_PASSWORD: unused
               STORAGE_PROVIDER: s3
               S3_BUCKET: hoodik
               S3_REGION: us-east-1


### PR DESCRIPTION
## Summary

- Hoodik panics on startup if `SMTP_USERNAME`/`SMTP_PASSWORD` are unset, even with an unauthenticated relay
- Add dummy values (`relay`/`unused`) — postfix on port 25 doesn't advertise AUTH so lettre skips authentication entirely