### PR TITLE
feat(auth): enable pocket-id email notifications

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
               SMTP_PORT: "25"
               SMTP_FROM: noreply@mail.thiagoalmeida.xyz
               SMTP_TLS: none
+              EMAIL_LOGIN_NOTIFICATION_ENABLED: "true"
+              EMAIL_VERIFICATION_ENABLED: "true"
+              EMAIL_ONE_TIME_ACCESS_AS_ADMIN_ENABLED: "true"
             envFrom:
               - secretRef:
                   name: pocket-id-secret


### PR DESCRIPTION
## Summary

- Enable Email Login Notification, Email Verification, and Email Login Code from Admin
- All three were off by default; wired via env vars since `UI_CONFIG_DISABLED=true`