### PR TITLE
feat(default): configure affine smtp relay

### DIFF
--- a/kubernetes/apps/default/affine/app/helmrelease.yaml
+++ b/kubernetes/apps/default/affine/app/helmrelease.yaml
@@ -45,6 +45,10 @@ spec:
               AFFINE_INDEXER_ENABLED: false
               # Authentication
               OAUTH_EMAIL_LOGIN: "false"
+              # SMTP
+              MAILER_HOST: smtp-relay.networking.svc.cluster.local
+              MAILER_PORT: "25"
+              MAILER_SENDER: Affine <no-reply@thiagoalmeida.xyz>
               # Storage
               DB_DATA_LOCATION: /data/database
               UPLOAD_LOCATION: /data/uploads


### PR DESCRIPTION
## Summary

- Add `MAILER_HOST`, `MAILER_PORT`, and `MAILER_SENDER` env vars to Affine's HelmRelease
- Points to the internal `smtp-relay` service in the `networking` namespace (port 25, no auth)