### PR TITLE
fix(cnpg): update CNPGLastBackupTooOld alert to use barman-cloud plugin metric

### DIFF
--- a/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
@@ -11,7 +11,7 @@ spec:
       rules:
         - alert: CNPGLastBackupTooOld
           expr: |
-            (time() - cnpg_collector_last_available_backup_timestamp{namespace="databases"}) > 93600
+            (time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="databases"}) > 93600
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary

- `CNPGLastBackupTooOld` was firing as a permanent false-positive on all 4 CNPG clusters because `cnpg_collector_last_available_backup_timestamp` always returns `0` with the barman-cloud plugin/ObjectStore backup path (upstream [issue #380](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/380), [#8902](https://github.com/cloudnative-pg/cloudnative-pg/issues/8902))
- Backups and WAL archiving are healthy — last base backup 2026-06-14, WAL archiving continuous to versitygw S3
- Replaces deprecated `cnpg_collector_last_available_backup_timestamp` with `barman_cloud_cloudnative_pg_io_last_available_backup_timestamp`, already exposed on `:9187` via existing PodMonitors