### PR TITLE
fix(default): configure hoodik to send directly via resend smtp

### DIFF
--- a/kubernetes/apps/default/hoodik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hoodik/app/helmrelease.yaml
@@ -48,12 +48,11 @@ spec:
               HTTP_PORT: &port 5443
               SSL_DISABLED: "true"
               MAILER_TYPE: smtp
-              SMTP_ADDRESS: smtp-relay.networking.svc.cluster.local
-              SMTP_PORT: "25"
-              SMTP_TLS_MODE: none
+              SMTP_ADDRESS: smtp.resend.com
+              SMTP_PORT: "587"
+              SMTP_TLS_MODE: starttls
               SMTP_DEFAULT_FROM_EMAIL: noreply@mail.thiagoalmeida.xyz
-              SMTP_USERNAME: relay
-              SMTP_PASSWORD: unused
+              SMTP_USERNAME: resend
               STORAGE_PROVIDER: s3
               S3_BUCKET: hoodik
               S3_REGION: us-east-1

--- a/kubernetes/apps/default/hoodik/app/secret.sops.yaml
+++ b/kubernetes/apps/default/hoodik/app/secret.sops.yaml
@@ -5,22 +5,23 @@ metadata:
     namespace: default
 type: Opaque
 stringData:
-    DATABASE_URL: ENC[AES256_GCM,data:TVwM0wAvLVUJ8vMqaIdUU0y2ccyiHwkhPTQ7wDLli7z+pXaPyD6vrIen4p/aETsuWufqI00QswaAmCVerDUOq0BkYzaitBx2Uw/eJ7kx/YT1k63Wfv5qOLVm2vd/pTSeAUt99AXKR+oedj9rlNJsiTf2,iv:9dmc8ckaFXilV6gIjZ2KQuD5QNbwNfjhN89D81Yfcyc=,tag:s0J0SoT0PqmQFEJlyULJGA==,type:str]
-    S3_ACCESS_KEY: ENC[AES256_GCM,data:Ak6VP2DZ,iv:yVNbWatatkAZUKmbBONwOTFDqjSWrD32gIZ+USiwUKA=,tag:xFpdBTWTrrBLHjysRQq21Q==,type:str]
-    S3_SECRET_KEY: ENC[AES256_GCM,data:nZTLMXf9iuOc9Gyt2NSaNPZOj6taTGr/+GhD07nSi+MeAB6TQ/7gnw==,iv:GexhmKTOnOl9UgPWSNJAKvnzeSh/YfUu2FfYd8PAm6E=,tag:zIiawTUAGsZKn0lYKofH7A==,type:str]
-    JWT_SECRET: ENC[AES256_GCM,data:t/vqRwx9F+m/JSFSnRrz60amgejBHtFmKirHGRFUjimAb0IiTStC/VlOm4KYXc5ZSAVqHCJikoM21r+9gHg=,iv:XrqKn/Af1Clxn/XVlE896jbcExCwRfs65WlBe79XbQ4=,tag:uEP4BQirRALcKdgIt1Rn+g==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:5/QesJCJCkCSzz/AsuQOY5kcoIas1N41KngB14vLoQ9P3JIn/MaMJ2CVbEkB/W818P4NKIBhiu9qInfq3ZA8Ol9ecjoUANO1WmSXluqKl44EScX+VKVBe2rSPanMr8vNmBouTkT+A+Arqgjj2W2Gvv21,iv:AJQLXwuEDecDIAsk4d1EoIk2TqmIQ2QELKGFuLezCNE=,tag:UMBBmGSF2oZpT4kUE+YM7A==,type:str]
+    S3_ACCESS_KEY: ENC[AES256_GCM,data:xSWpy79k,iv:DN8jlnFmzS7ISHeBOmYyzkdLNe0RLJ3kuw9hCr/jzNE=,tag:Ie0JtfdnP0JfEyfsHF5sDw==,type:str]
+    S3_SECRET_KEY: ENC[AES256_GCM,data:z2uVMMuCH66wQajkvl30BuU9a0fFuHk6EG+3kfpXAIajMSqyvwlJPA==,iv:gmWdHA4PELaYabds5+HMthGtwiAd7d1XlV4ZnQSW6TA=,tag:T/L8llSPv8m7YW9RID/Fwg==,type:str]
+    JWT_SECRET: ENC[AES256_GCM,data:jhzVIRldZP+vpX/XhviSAAIUPGPqHDrGkWWA+hzEh7O/aDromCrjDSxiPjTTuJ5HAXlvKTgnsOaomz3mk8o=,iv:Ka+17VGbu6wIScsKti/SiNLi9KKAVQMu1nEiYDSKae4=,tag:Ov72QiVyIROanOJYu2Z80w==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:hRpVKkPOPN9AivWUMuVvEkVRdvwRweV1BIA7OtoQudMJE5pL,iv:JqnTrrdyw5CuA3GOayas5tdb/205NHJX+icke2W0QEk=,tag:KlLHtGugJnqjx/IiqT1X4g==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCWWVHbC9ram1lbDVWYWd1
-            TmdocGI5T0JBNnUwNEQzdGJZNU5tN29ydENVCmM5NmlqVDZpbzE3eFRPL2ZlWTl4
-            Wit1YWNuTG5iTkdVejhtQ3h5c2NxalkKLS0tIE9hbC94QTkwdWl2bkx0dnl5Qk9h
-            VEw0R1cvTXZVKzVSSTVMTHJFMXp3ZTAK0Aud+/BY5ia5hYgBdB5PSdWWKMUojPtE
-            WRvNz+2ttjj/QoDrLSXor8mptwX9nTW//qCU4dGT3oEMqJnG4935TQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRcW9CZmhxNUNxZHdMR2ZY
+            dmNvU3FoRGd4cS9POCsxa1Q4dmc4UmYrWVhrClRmWUFReUozZHlaWTZObHJDWEVK
+            N1R2OGpuNGpzMzlTTGVaL0JDN3RreFUKLS0tIE9SbjlnZmdZUTlYcUw3KzRNUFJy
+            YnVHbTJPU1JhMmhudXhvUnhtM0YzdjAKRthdaNuHXEDvWbKjehTRvUWOYuM053kI
+            Xna0KQ9FcjF1NkBilxGCOqnesLnmdvWfB1t9IWkFH3kKjRZ9jgClSw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T15:58:24Z"
-    mac: ENC[AES256_GCM,data:EsJYMQvm/D1sFws/F2f1N5XUzoAnKpv9zQ2h6IKc2JLUFQDp6+rxtb28OsPPBo7Xg1YXB58ae0UgKLkWO0RZMDz6f3o7XK1RJQRZtOBw+Ydf5373b24KmT7uYtR7S2EyeP7de/0W0q/e95TMr544e94Netl1kBhCsiAqlaTeEoU=,iv:/u3iQ0jWjr4RIDWQYCd4UAOAf0GLZ5KiBz4+iLU7jMg=,tag:AxBSMaDBGftqbgWzXD5byw==,type:str]
+    lastmodified: "2026-06-18T00:16:41Z"
+    mac: ENC[AES256_GCM,data:TkQLFXi/eg3WFraEmaBOf9RMvglLSr5l75JR8iUlHkOkOSN+Vswn1rfZzG86pCYS5cWwY+Hkw+Kr4aiHk9m+jk4b6oXfl4tk6rQwwmw/3lM23HHxv1mXTmZCgFnszuMjINnDuIF8xS7HrmMD8M9IniWivgXu4grJes5mbc15+tk=,iv:7btLGX6KQcpidQ7TbBS9AfjG0SzYPRJH/DBJspfOKss=,tag:rE3C0i1DFI38yrEQTDP3dw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary

- Hoodik requires SMTP credentials and lettre fails when the server doesn't advertise AUTH — the unauthenticated relay can't work
- Switch to direct `smtp.resend.com:587` with STARTTLS; add Resend API key to `hoodik-secret`
- Remove dummy relay credentials