### PR TITLE
fix(media): fix oauth2-proxy startup flags for metube

### DIFF
--- a/kubernetes/apps/media/metube/app/oauth2proxy.yaml
+++ b/kubernetes/apps/media/metube/app/oauth2proxy.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: metube-oauth2-proxy
+      annotations:
+        setGateway: "false"
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -27,13 +29,13 @@ spec:
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           args:
             - --provider=oidc
-            - --oidc-issuer-url=https://auth.${PUBLIC_DOMAIN}
+            - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
             - --upstream=http://metube:8081
             - --http-address=0.0.0.0:4180
             - --redirect-url=https://metube.${SECRET_DOMAIN}/oauth2/callback
             - --cookie-domain=.${SECRET_DOMAIN}
             - --cookie-secure=true
-            - --email-domains=*
+            - --email-domain=*
             - --skip-provider-button=true
           envFrom:
             - secretRef:

--- a/kubernetes/apps/media/metube/app/oauth2proxy.yaml
+++ b/kubernetes/apps/media/metube/app/oauth2proxy.yaml
@@ -29,7 +29,7 @@ spec:
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
           args:
             - --provider=oidc
-            - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
+            - --oidc-issuer-url=https://auth.${PUBLIC_DOMAIN}
             - --upstream=http://metube:8081
             - --http-address=0.0.0.0:4180
             - --redirect-url=https://metube.${SECRET_DOMAIN}/oauth2/callback


### PR DESCRIPTION
## Summary

- Fix `--email-domains` → `--email-domain` (flag was renamed to singular in oauth2-proxy v7)
- Add `setGateway: "false"` pod template annotation to match metube's own config and prevent VPN gateway sidecar injection