### PR TITLE
fix(k3s): remove unsupported labels from workers

### DIFF
--- a/ansible/inventory/host_vars/cn6.lan.sops.yml
+++ b/ansible/inventory/host_vars/cn6.lan.sops.yml
@@ -1,63 +1,61 @@
-kind: ENC[AES256_GCM,data:xss+P/jW,iv:DeXXyJMxvgjNyIXJ82o25oNX8Xqmys/VL3+mFGMus2s=,tag:5P7uHZKQbYTMJm621FWXyQ==,type:str]
-ansible_user: ENC[AES256_GCM,data:d3yiMD2y,iv:gcaFo0vzRRuUrcBunMID2H1FJQXydCqSD0w/gglNRBg=,tag:meoviNkj1hyj0dDq+FNXbQ==,type:str]
-#ENC[AES256_GCM,data:Qaonqa3ngBM36SecLETp84YhFLZ3tApQNjhUz6NlvcdoV/B6N5x2n9MKJiLOVf8bazResI8xOYzlP8KDyesA6n4SGE24lw==,iv:Fxs+tyfOV9VQWBqngEVW9pV1C5ogu1H6dMHqDQFjK0U=,tag:LYdB6Z71Pi3o07KhW7/e3w==,type:comment]
-#ENC[AES256_GCM,data:68liZKLYlDNChoN8aeHi23feoUDT9BNyq7Lz9Bd3fvN0d29qGXJkJlB0SOOevCXvlzGyBqg3ATMbmBQzPAWsQJcjuk+lhMb+Mr8=,iv:v8ROeZN25t2vbinwMjQ6KD3SRYFbKv4iR4TBIpcTwu0=,tag:pU93FX1HgmlCBiG5MAXbog==,type:comment]
-#ENC[AES256_GCM,data:FvL8S6JT+NU0DtwfK2s2FOHqYq86trCmxyhqNtIWfEdQWOYDYgvpN4ej+Jsu8ICLRXW64c5+POZOiPKGgLgKJWBJs7IgkA==,iv:rhaG+fyi6fS/skIardhObnh9Qya6LWdEaRmzY/FPmR4=,tag:V+6h9e95n65GqbAokZLY6w==,type:comment]
-#ENC[AES256_GCM,data:Z/01ONXWupipXXsSH+p0Ul+GGXA22kvx8MSj+WYkVZA=,iv:SAnthGh+WVjI/QvMQTsHCfgFiB6/IzGz99sEGxrrl0g=,tag:ZgLkMDngR67zabSGATOmlw==,type:comment]
+kind: ENC[AES256_GCM,data:66T6zDl7,iv:eGnCROJeZlINUOdUlsgSQC8wSjMwZgB65jqpZkqwtqs=,tag:5L5btk29IWzCtacr/mh72w==,type:str]
+ansible_user: ENC[AES256_GCM,data:Zmz0beXq,iv:7hUW07ZAPCG3+Tj6vggL8mCij+qZV8MbWcPKfoC4xA0=,tag:3Y2mpckdIQqON8mKb5A/fQ==,type:str]
+#ENC[AES256_GCM,data:u/mrQgAF+xtISIus76befKJ81kDGXON3RTKoauAxjUZn8lblZR/53qjDUr6PWhVHM1ta3V9hiDcwV3HMpNjVe7KwCk9Egg==,iv:T7apIdZmCNvBMpxCDUHrm0VdcP5kQFTitKMF6q7M3x0=,tag:3f5tS2cOpxYX/CnWR+eXEA==,type:comment]
+#ENC[AES256_GCM,data:xxB3cogSkucfNANqLHm/eH2CxATvOmR7qfCGoMcq+LDBSg4yoiSA6H8AnGTnqX1MFKQ0j0hGmourjKwh3cBD8x5MEf+mVHf5ybw=,iv:8Vu16GJUtdDuxGusxE3Fch2/Mt2WvXX0/9ZYjweyl4w=,tag:3LVtQeraZKSVnpSpRy6y+A==,type:comment]
+#ENC[AES256_GCM,data:QI3qtyWHv2E7BGwDiT5+ErT3PobOmoqoricvkZyZfjE0pOT2vaNnLkQE2DmFg3RrS6K6RKV1wnieC97QYZxeUaw+tCqHvg==,iv:kDZqLc6g5Eip1Yo71Na4SakpbHSX+r6/rReAnDpaask=,tag:bcW6WgagOGd5tb/CDFDyFg==,type:comment]
+#ENC[AES256_GCM,data:W6pFS5SGxRv3iEs8H44mg8qA0ncCHfK1puelBlbRYks=,iv:/1HEyudvMaJcb11JnqtPiPHYlrRG0Cj7Sjmrm0jNgp0=,tag:a32pVvj0efxAPaQjSZhLqg==,type:comment]
 k3s_server:
-    node-ip: ENC[AES256_GCM,data:jGYCOElkCv4rrgz46SOqf4fR,iv:QgpGgtc3Ot7bHM9L31eoShkk8PdgBET5GlPE0gfeUe0=,tag:3YRBNhzrveBet9/LeoaohQ==,type:str]
+    node-ip: ENC[AES256_GCM,data:7QN4ResjGBlKaZlM+G5m4XeE,iv:eJOKH5Vo1USNpqw76nEIEjOHsArfVM7h9URh4Rv9ARw=,tag:FM7ZqLRdsKtU7RoZTN+CkA==,type:str]
     tls-san:
-        - ENC[AES256_GCM,data:8ErBR/cvixlQcwXnf5DB2mxDxJWs,iv:if4zsuptXfTADZAPscuv+qhgW8YTfRe2M95SFxvM80U=,tag:WAz0K/AT8x/5ziLwW7G9+g==,type:str]
-    embedded-registry: ENC[AES256_GCM,data:bZUZlQ==,iv:1dkpKdSd9JmLS49kJFyc7y4X3raBYhL5cJTqEJQD1OE=,tag:QNlwN8h6+kcTCEprqNp5AA==,type:bool]
-    docker: ENC[AES256_GCM,data:33uRqWQ=,iv:OL2QD/os21kKb++z7jUoVehcwXF2ULwZUiJBBTyYdUk=,tag:6bnDjxpu49KasFZp3MLmRA==,type:bool]
-    flannel-backend: ENC[AES256_GCM,data:fc3OzA==,iv:WN67+z9B9eycDwK/xPpK6fZbMbO3nBfwGwXsVLCBNOk=,tag:9ptwmG9R7Q+B39DUmaAkPA==,type:str]
+        - ENC[AES256_GCM,data:ApjOROJEW505osUFt5HUUUu/kKFE,iv:Sl1Lq6D834tNJmlMkUd5Z77pWkAQQI0yhvIt0uTFX4Q=,tag:3P7+LV6dT7r18NacKwgNZg==,type:str]
+    embedded-registry: ENC[AES256_GCM,data:1PYnUQ==,iv:7iqGIMEcbnX6NJhspepOb9DaAo0y0GV118Mi6egv53A=,tag:8jJKWOnw5DxkAaDNFPAYbg==,type:bool]
+    docker: ENC[AES256_GCM,data:LJS1px4=,iv:SsIl7zNpYca5V0qnFkdxCoir80CgcCvThMiZsMQaAI8=,tag:4iEtpTvtWUbfH6t2rU1EIQ==,type:bool]
+    flannel-backend: ENC[AES256_GCM,data:zZDXsg==,iv:y8e3IbnpLCQIFoAO7XUSyNva05z1Z7VauhoR1ozPt38=,tag:mh7aSpfGnM78FIXgwPpOsg==,type:str]
     disable:
-        - ENC[AES256_GCM,data:FttXJg1ntg==,iv:W/XDIkXIwLhLwFR5p+wIL5jE6FxX9JO4SPIiztDjL34=,tag:ig54rkg9vGvrexj5agWqAA==,type:str]
-        - ENC[AES256_GCM,data:6nhXs9GsO5rBAWyKfQ==,iv:OrZNSiRqGN9SYAl09yrgQD8nSYv6RdGiVQKyMpuqc7U=,tag:Qj2pfJhV103/q5KT+MWKxQ==,type:str]
-        - ENC[AES256_GCM,data:LnpActms4kLMQDmIL9g=,iv:M1Oktp5EpCiTP4bP50Rt0uPgxIFxecFabxCpHW8Chj4=,tag:1mFHrn9UTCNKQqu6aAFi3w==,type:str]
-        - ENC[AES256_GCM,data:11CN3otANFAC,iv:XLfHD7qGBVpSGSOA0564dRTyd1FgkmS4rhdKRhzDIjU=,tag:5+qfXYPPPQKWCdSXuBUq7g==,type:str]
-        - ENC[AES256_GCM,data:jbs+Ns7UvQ==,iv:tcfwequpRZOs0UM8iR6ziKCGp6lMpiMGxf3eZ/0GjqM=,tag:MLrngUBU0keFEw2zBwEu3A==,type:str]
-        - ENC[AES256_GCM,data:Y51epVpkpQ==,iv:RZnDBmu47R10hbd8Y+q3EdgSMXSefDUBl5xSeu80/3w=,tag:E6Kq4Xtnx24lLewa1L77XQ==,type:str]
-        - ENC[AES256_GCM,data:GH8sxzea3PRRiA==,iv:fTwsqzR1kdg3uVlI5lyTNqUzKu6+GeGMX4L42cTVjDI=,tag:mXgUDeueFs1/9Me0XDCFcw==,type:str]
-    disable-network-policy: ENC[AES256_GCM,data:IXM7ig==,iv:EyJQkmUuM8tyPiWeGW1QeZ5FSMzp57s/69Sdvk3uzaM=,tag:Vwy57m2hYE2ejxDNdiN2Yw==,type:bool]
-    disable-cloud-controller: ENC[AES256_GCM,data:vTc3Zg==,iv:cOE6VvLElJZG2htqmmQjYCC56rWhz7ItjhFEdq8NWL4=,tag:6mcm71KeEclfVMO2AuGQjA==,type:bool]
-    write-kubeconfig-mode: ENC[AES256_GCM,data:pJcN,iv:/VYaHh3zTguLRFW/5byh6s/sx5wGNEu+LeQCpI+OeDQ=,tag:Pb0LJDMh9ibUY5WsviDbLA==,type:str]
-    disable-kube-proxy: ENC[AES256_GCM,data:vAzHJw==,iv:5bZ0PdlN07Y7ODphZQ+qf7APSIITWRLvabdS8iBYnog=,tag:W5xsAQ+HW2jKU9PIQeUBAA==,type:bool]
-    cluster-cidr: ENC[AES256_GCM,data:5Bt6a72cFAGbGFi7,iv:NfaLDbATcPFZSMtTytpnDACLWqF/IuoqfsF1cCsy1Lc=,tag:Q9f4SmK31LJz4PjY3AMnhA==,type:str]
-    service-cidr: ENC[AES256_GCM,data:vhHbSsEXSMXkpv1E,iv:9keeVZJ4dTpfcsxW/90Wa9rWbeKjlRbEsXvhLoHAaTs=,tag:Qz4hxKLh44rxmoY6qm1MGA==,type:str]
+        - ENC[AES256_GCM,data:RHBkPBVmtA==,iv:sXiINb5ab4YyRMyzAGqs+aBH8xzOSnlexT+vo139DiU=,tag:Qlv5LnUdK+LAkhzaKMtPbA==,type:str]
+        - ENC[AES256_GCM,data:hzldngulNt30F1sM6w==,iv:hkJk9dQfrodg2d2Pwa3wFtlO5FlxDdSZHVhxebYCJnM=,tag:PcG2sz2sq53M3KOy9vYjQQ==,type:str]
+        - ENC[AES256_GCM,data:1qMAvdPCb5n8NRRBRbI=,iv:qYbkVW1WHyE94UdKZcNCMITSbfPloA14PWYa2aCGdbI=,tag:xIzBpygiKVomYzWwTxzgqg==,type:str]
+        - ENC[AES256_GCM,data:wl4op0wNG2po,iv:HZVABfE214pFGp97Y14izKuxsSkC+ekCKDzdKlGq4Nw=,tag:xOkGlCtSQcI09ovhSdtoLQ==,type:str]
+        - ENC[AES256_GCM,data:HPddv8Ku2Q==,iv:BCPIXyRB7XMotAD+Wv2PywJDoNkDSYvFlhrIBBIwtVU=,tag:lrGtgJ6QW6YD9SG4z9AZrw==,type:str]
+        - ENC[AES256_GCM,data:OrzLfPcfaQ==,iv:A5fcc5Wtt8799FhB4Ngp9oWJYIqLio4+6YY0gZkMv5I=,tag:P0pEK6gwgbDqZnHOwkfLmw==,type:str]
+        - ENC[AES256_GCM,data:qljyQd/eSOloKQ==,iv:Qw8KCu/DY9PM3XULOiMAsAKf1c9fHnPAIOHyvm1auDg=,tag:7FIV8T2hCdhrnrexXx51sg==,type:str]
+    disable-network-policy: ENC[AES256_GCM,data:+HVi7w==,iv:WCEDwdKLypNnBLyHJ/2ahenSCb2HCABOjc1dFc4gZLY=,tag:j2FQJnViqYGqPPIHCXnXfw==,type:bool]
+    disable-cloud-controller: ENC[AES256_GCM,data:GxGBGQ==,iv:mxhWE+/QX4QtLP4wpxegZOcWP0ycPOQSC+oOtj++E9o=,tag:F4RO0Tg3onavWhIM7gga+Q==,type:bool]
+    write-kubeconfig-mode: ENC[AES256_GCM,data:Nrf9,iv:rzGk84s1hmIyobBLUufh9wmc1wmEKaX03+2utGjy8k4=,tag:OrTbSP8xnrBR1WlL7PqhSg==,type:str]
+    disable-kube-proxy: ENC[AES256_GCM,data:D0de4Q==,iv:PID3CbMvM4ESHQCMo5SlX/4jA9qQZ8S8wfjpSmv3fmE=,tag:G6D11KPQS7lg7YZjjmrKdg==,type:bool]
+    cluster-cidr: ENC[AES256_GCM,data:77QMrTCSqWk2PkbB,iv:/IU0iUmKHrHdq6xejSVi2DeaxhBiqDnlNMrr9s858wY=,tag:SlmDjvI18KmQ6J9g1pU6/g==,type:str]
+    service-cidr: ENC[AES256_GCM,data:WTle4+9qJ2ztGzu+,iv:TyRe3icYGCNu/05QwAvjDnMOjkmSBfZ65y+axe2vkE4=,tag:44j0tr7RpLzgNO5hPDWbyg==,type:str]
     kube-controller-manager-arg:
-        - ENC[AES256_GCM,data:3l2kj9FATnncNq7sisLfLw5tzH4=,iv:vkgD4420oti7uTp+i4gK88Ca2DcaK0QSeaCfLTqCvrA=,tag:L5gaS0d/iNf6ekq8JVDFvg==,type:str]
+        - ENC[AES256_GCM,data:4XrHwYrxF8vTTSUrBljp5WlDscM=,iv:8iarEtOBfmDsToo69+u+rbmH+Tx8R8cZErYqVo4a+n0=,tag:9fieVNPCy+lYPEYmwRVl+w==,type:str]
     kube-proxy-arg:
-        - ENC[AES256_GCM,data:AjHs/ll4CwlGP6rQX3Cu8mdlj6N79dd8hLjwBQ==,iv:irCuPcZI0ckMwaJmqiE/3cLkZNan8YsbrQi4ayBhHRY=,tag:ZyLGssa6Czp+hJYw3033kA==,type:str]
+        - ENC[AES256_GCM,data:hJbep9H3Mte0+K7uzZAR/fV8mOEEIjWSTVvMSA==,iv:my8+0MnSv98DnHi7qtWUurxFEX2+6ESRDDTiRTESAmw=,tag:UensclVi65a8579dK9F6aQ==,type:str]
     kube-scheduler-arg:
-        - ENC[AES256_GCM,data:QgRE8Hhov1UPu3cirzSC8HEeWQk=,iv:akEtDQd/EiXPPsV+9ZMpmnUgcYqKo3+QT7oUpFoPJkY=,tag:WPIVNKencsd7abRhmJuusA==,type:str]
-    etcd-expose-metrics: ENC[AES256_GCM,data:Nj5H0Q==,iv:TxNcc963ylnowWEiQYd6LNMozQ/BoxxfOukb2jwVE1E=,tag:taQSEOycoknIpayptUQYHg==,type:bool]
+        - ENC[AES256_GCM,data:/hv/03f1zKXO4DMJzvlKFNirZOc=,iv:+ZR+U7fqMItMdXxjevPRXroNqKYz7VcyV1VAD1dOqtQ=,tag:/A+jzdZBOTdKifoBgJEKdA==,type:str]
+    etcd-expose-metrics: ENC[AES256_GCM,data:9j2xOA==,iv:9R6EBdBrUrSZpPSBArXvrKNCos6eXOI28oZsPmyabrc=,tag:tBrYspAikmCAW5QJdYMRnQ==,type:bool]
     kube-apiserver-arg:
-        - ENC[AES256_GCM,data:8Uvg8xeucapOyah/iJmvmKsbqA==,iv:60/3BZx0t8sNUL+zfA1qhn21yrje1JHZEdwTWFW4rJI=,tag:h5HBzHa5iOm2mEBuy2xCcw==,type:str]
+        - ENC[AES256_GCM,data:ZfI/o2ftGILY6G6i+FLJiA/Ryw==,iv:/4vkHQp22MBRhTag/2FSTBWwlYG5hItLKxU/T8BsygQ=,tag:6HWyBBWrJsKpN/4u/mp4eQ==,type:str]
     node-taint:
-        - ENC[AES256_GCM,data:SXirkprhDiG4tCXRp3OzAR1e1geLsV2or+lckDz4YUKlvsm02VBdqA==,iv:xwcciznK+bNayfSZm9HjmGdrciG0KoshJhYFGKfi5tg=,tag:HN/jbYr3YSIECbM51xzBSg==,type:str]
-    node-label:
-        - ENC[AES256_GCM,data:Iggc6Z+kMwvEuKYvf/+kv78fwlqXyshmLGA1McsV,iv:c80p0ycfB1h3aB2tYVyx7vwSrGm0s1hk6nAWJX/f6Pk=,tag:kqtnXGCWdvQ66xdXGx3snw==,type:str]
+        - ENC[AES256_GCM,data:VYKJ3YU/gOyJAPRsa/hgAC41XIHy4LAjdDFHK5zLtNj4w96stWOt9g==,iv:iJn0HxTfkhB8icjhXeq3rTw/VOdeU+PGkowFOfYegwE=,tag:RG4ArRxihqVPUC4X/Vr4Mg==,type:str]
     kubelet-arg:
-        - ENC[AES256_GCM,data:qg9LX8z0c1oC297MRqWYWsXC4si0tq0/zCOCbpLn4Qwq,iv:kamL5q10O+4XDy5kgrKuIg1vojocyJw7pm/d6iz0iBE=,tag:32Xjx/VrMO7oXyCRiO6jSQ==,type:str]
-        - ENC[AES256_GCM,data:vGFDUOTxI7gdM3UzDF3mBgQJZor3G8P4FXHyyTAnxwPzoCCHjA==,iv:P9JtSsDeMkJz6wAnGtFnedcvE0Ox+7Pu38QjF1GvHDk=,tag:V6r3WwcEmfP7bTJ0pXQwaA==,type:str]
-        - ENC[AES256_GCM,data:TqA2HPRBKv8l7kxrYBfmSxpjLCMC1LGTQg==,iv:w2QBUBBKHvKTN/vViUUaurP0Mj3VnxLqvjj4P9PfHZs=,tag:B4Z45etWG0rdXyXN7T3i3Q==,type:str]
-        - ENC[AES256_GCM,data:LmwDwxtE9Hm0rd/R6Dmy28nX3+jRgLupyVA=,iv:AafNVfjBG5WfUSh8oxjWquLJhnEWbvooGPHwN+yvt+8=,tag:R/qhzdg56rPgKUUDr61lLw==,type:str]
-        - ENC[AES256_GCM,data:v2FzG3XN2RiK9BuDnFwIN+Rw35+a6ihLh27Q5Gv3lhVx3LqRB7/0PqgG6x/lBvCoXx4bTIWsWbeh,iv:7F10iy33Gq0U4qkw9Wiplzqi1cahrRM2SjtOpHTiKvE=,tag:EtGHwYa2QZklYb/I9z5c/w==,type:str]
-        - ENC[AES256_GCM,data:n6s1nEnRzr/U7F+W//I/waQqYO5EtwyInaFxRR6VP4AgM3J7dfDi7N0VPFsI98vQUT9cVo5Aw0Pc,iv:JQ1rMx8hZ0vwqOeN7nD8SzZy4iueuEgl/3NFArKDqOk=,tag:gj+2TQbcRHsUsfloNrIYVw==,type:str]
-        - ENC[AES256_GCM,data:J/EF7tg8sOacDo9bw8I+HxrYZetk4TS6Kan90Ov1n95q66lZ4BjrM4+3pi64ldoD3Rh7OWyaFl6Eo+BbJPus4Qhn,iv:eHnZprlrjc+XzfRJwh+objSwy3XhWZDrWReFy6w3tSQ=,tag:BDHJ57XbpZV969bh+Lwclg==,type:str]
+        - ENC[AES256_GCM,data:uQsZozrebnKV4LGyiWk8TmAVO4hGFc1FZNkY28aJ10fF,iv:aP+nRLHImpsnO/EHZC3/KQLeMg3zVepQAE1jv792TCw=,tag:URgMB64qMsVclPciDO1u2A==,type:str]
+        - ENC[AES256_GCM,data:21tmok+DNCDNoa6V4X0A/HL3qtJY0pUyTf8Ggspqxtw70wO1+A==,iv:1qKrHhWLe5Z9j5gTJ22lqaMfwS9AebVh+L2xsXlb8wg=,tag:jn36Z2aXSCFTmYeJHx3oQg==,type:str]
+        - ENC[AES256_GCM,data:s5SHZ3Ii94cbSU5mFvFjVT41jmiJD7Av5w==,iv:n514ftROty+vjiww3Y35dSkjGHnpX3gIBvncJlT3WIU=,tag:pTnGwXYD/KVDKqCzvGJIGg==,type:str]
+        - ENC[AES256_GCM,data:Mq2T58dVwSa/MSTf9MNvP+rKUZlAPTkdfhQ=,iv:pJIGmQNkFsQ7qViUOYXn6Mf/aCBcAjYYm01xahrbTUs=,tag:TqXC3jEvIchyU+3sA1A//Q==,type:str]
+        - ENC[AES256_GCM,data:db9wum8VIm+5ZN7omi7LUjsBKpFfus8f+8PuVPhWZle2J9Z7rgyNBSuCX2H2cUXqWXecxCSoHzS7,iv:a3Q1woXrkNOlmdtJEuWadMlwhk5lW1FeX0NP2vucV9Q=,tag:ThwspEeYWVUQLLB7ldy3EQ==,type:str]
+        - ENC[AES256_GCM,data:ddw1aXfuFR0i9b5Qbm3pZJ8TtCa3BOk6RX1p1uz8kGAWcHWxAM/bdwEsxd+cLibTY9TiISkLqmsh,iv:1cnzzzQ7h7uwaaNDVHNSp+rIJktsD6JNgD/WiCVQ61U=,tag:eHWFOIWK5V/97xLuEmCFJw==,type:str]
+        - ENC[AES256_GCM,data:cLX9ZzxD5sDYEQXqz5tL+vqraaJYEfFIyzRVqIhhRaEhFnhQwOhgT6gITPYpYlWOP/mZ+7t/sftGHFJFICk9D6zM,iv:3JCumiYw4+Yu1yKYZ9ycLuls5qESo9JdZ39tooWihjw=,tag:JXbFrFPqUPnf4tQAEcnT9A==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtUUdkd1FDUmJ1dXltZ1Zm
-            VG1iZE5JdlRXVGFjWFZqTllHS05yZUJrWGdFCmxBd3h1OWE0aXN0bjRCVG5nMXRO
-            am9kSGJMakJHNHVuNXNhcndVYXR2ZkUKLS0tIEtSaElaL21peWpTcm5WY2YyeTIw
-            b3U2b3dndE5MTUtMZm5iMWQrVWF0S28KEmdKWx/avXztsYpe51PQZT377NxLOCmP
-            Hpd3gqhel+lYqAPHISMiRme3TUWI0BRs698dorQ61h6ljs6l0ZHoOA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAya05WMW9SSG1TLzBVWDhh
+            THZIb3dFNldZQzI1MG9OeU9SWWdHb1BHWmcwCjJtNmFQM1grdithZmEzN0tHdk9l
+            RXJQeXZBSkdBVmw5TkRENE8zVjl5MjQKLS0tIG9oYkIwb05zemhyclFIMVFhaU1o
+            U1BKSU03REo1UmNvNVhrVGZoelQxOVUKT2Y7yahXhpKzPyzrtXvL2YLXSkSpOPX9
+            Wfu7zP4Kf+oMFlDTYGBVw9eXZDWNP3qOR0ler1yLkw8/+T2E9Ne9Gg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-14T12:29:39Z"
-    mac: ENC[AES256_GCM,data:8g3ixbETeop9mr2wzilAt3weKQUMOH6uDtzsnp/3t0mv482aPGGUP3QAwnCE8K7jlNA9AftCNaDSf2FArAxG08pzbUhHjPL87kVa3e6LDJpJoIyS+X2DAye4yEWktezeQZDqSZsXg5BooeG8W4IewGc1uh14qGM6EOMu4hvdMY8=,iv:j+1j0pjFA52QFYVRbxvDU2qyXJxjGeFfnm2cTKj0UFk=,tag:3d5ZJliGuuouOzWujTNIrQ==,type:str]
+    lastmodified: "2026-06-21T20:51:56Z"
+    mac: ENC[AES256_GCM,data:n6kpTV4WfqEYgS2uLDnlPkGtqG0qmuIidl3q8hdtUhlmsu0VPIA7Iu8e6aS5y4vtTmN8FcU1XJT5qgd/RHL/n7WgSlS6alA5ynE0/XnTBOhzBjqTc1/ockuNIr+hW4QrX2Gx2xnKCO6tMsQenM7Hr4rb3O6rmV3fz/jd9eQR2ME=,iv:zwIH+uaVOip8Pk40xsysLza3dGQyiljQ3tZQDQRdwUE=,tag:aoGOLvhmXYvjE9iCZG8FPw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/ansible/inventory/host_vars/cn7.lan.sops.yml
+++ b/ansible/inventory/host_vars/cn7.lan.sops.yml
@@ -1,29 +1,27 @@
-kind: ENC[AES256_GCM,data:LujJnB94,iv:tpprVebMibyH5tISZM+Rwto+Yvb79fBZlc6dYlDLN64=,tag:Y+BaljK2/nfOmy1qQNnuCA==,type:str]
-ansible_user: ENC[AES256_GCM,data:pknV6m8F,iv:4ut+pNtfb4eiMWcz0zO7e77Si/nckRLFl+OUHiMQxms=,tag:0phWxzRol4+iPpis3PWxXQ==,type:str]
-#ENC[AES256_GCM,data:G9MdxmnMEfDOFaPv2G1SMqBiJUgZLEdeJ4crS6gN46oxmjymGlerDss=,iv:cBtVNOS3AJ5dwPjFMDU5pxRTZL5tldlNZiOyASxypX4=,tag:SvBNnQEDK2d4K4SAYIPJaw==,type:comment]
+kind: ENC[AES256_GCM,data:MslEFCWe,iv:C/VNZJvG0N0GBeKysw3o9Oxi0C0raCbaYaFwKYIfyAk=,tag:7ao/svB0VPMg8JYFofF4gg==,type:str]
+ansible_user: ENC[AES256_GCM,data:m4zhO3LA,iv:YYs9dnOzFjSc/jftclXvbnNTQL1swORvTOUzj+xPRjI=,tag:XJh0d9wTOU+9zrS/VA4Taw==,type:str]
+#ENC[AES256_GCM,data:X4Aqm9rsGlEOt8bp5fRvL0OaYB7IjP0HOunWEAIFPy8D64N9/9Q4ipQ=,iv:lADEg0cLlvUfbo5yk3us3U9zFZQbGChPyaT+nC4ENSM=,tag:S0piUAIoe75OxpOtll2nFA==,type:comment]
 k3s_agent:
-    node-ip: ENC[AES256_GCM,data:zVW6JovzJqERP299SyOIgfdY,iv:xesiZMp3bc5JyVbSNZoTvoqcCuPaMU9B0jecRXNYFw4=,tag:DQXdNgKtxoMP/HU/ddT2ZA==,type:str]
+    node-ip: ENC[AES256_GCM,data:AXUEggVQ2dhxiVLCRUn7BvGY,iv:SGOc//TTYpGNxZWLZGAer4/na4JNdiYL7Vi7+vuRJ9Q=,tag:zpvKxAaBhsug4drYun/z2A==,type:str]
     node-taint:
-        - ENC[AES256_GCM,data:vbYmt2HxK5tKjDixNci+ZhNHH5NKIiwkjVPOcqWfKSxLIBHLWMgnTQ==,iv:C57DJKsrJk/kS1vKYLYywBebHSRuGrrMrblepnBi868=,tag:tRs/gry8EYp2TWGYTgr1pA==,type:str]
-    node-label:
-        - ENC[AES256_GCM,data:Wt5T1rOW1/B1m0mz3mJEYhuAVF6adasOfL5v/zvv,iv:a3vTzNtvltasVl9lrzhb2oVp2dKDeGDkPsiwLIPLUHo=,tag:eZI7a4NB7xhtCCKjmUK35A==,type:str]
+        - ENC[AES256_GCM,data:Wr+0mWlcjUgWyhIOoTUa4cvsW8Z+UwMeTzsAe1hpeZXAsTHqchoGAQ==,iv:UlV/hRjEE3vciaz0SDmYwSGgcHFUiWRIYqCN16C9Qn0=,tag:DZe/HRZAKg+xnMjMssVIbw==,type:str]
     kubelet-arg:
-        - ENC[AES256_GCM,data:uWC4wonWif+cbMbKV+EmWD9Rg/cK8hclW8fu4I0yiVl+dKQ=,iv:dxYINQrobubsYXUmbif8HAm5Pz2QNHe8zK+Jf3TnTM4=,tag:anLIPviLJudqCU0miwmNuw==,type:str]
-        - ENC[AES256_GCM,data:4wIwcBNcd9qBZwM4/7TDl+LU/RqHZq65dHU4hg2T7GWRcOFRRw==,iv:8Xsf5KltUCIqFegiZIZD1A9Y/3pT7GaI1k/R2u0Te88=,tag:8V/FEGL85x7n7l4YHPV60A==,type:str]
-        - ENC[AES256_GCM,data:8TTqeRfeOEsgjNMyrxARtvVBeCo9Q8jJTw==,iv:I6jm9FWNh35ykYe0iKS2beysKT6ISzGQqRyMFxj6kZE=,tag:D4w717ItiMydWFESkZIr3w==,type:str]
-        - ENC[AES256_GCM,data:0zcYB7zgAb06egOfQ1/Qb6LaGfA5p9/cjFs=,iv:06ZUNVWQBfqZqhyBCUzvhQWQyFyXnL0Bt65qmW5/YJc=,tag:l/DGNVE+uu8zjToNnxB9CA==,type:str]
+        - ENC[AES256_GCM,data:2KsW6rr+FugJZOod7x0KVsVQ0fz8te+uRgT9SaXQWA/Swrc=,iv:OVO17jBzmt3PrcWW1x8KloZsKy3d1PGC7x5kddvDy08=,tag:kEFmUn32AKQAWOLFAmJjqg==,type:str]
+        - ENC[AES256_GCM,data:Vt4pVIbvOZlqBW5uWuqpFp17oixDKL5dgUIiYFBtep1lnHNNeA==,iv:1Ojzyt+szgAh7Y5D5iDRfkYuxZFLVmjUa+tQpNm7jmY=,tag:l0zsob8ZdV6HS1txPJJHZQ==,type:str]
+        - ENC[AES256_GCM,data:+oD5MLHlkR/EyvxJtWkpQGECI2+2WFijxw==,iv:buUO3Rh8Usn9I9iDfE+xRESMb22KpTSPjI8crSB7bLI=,tag:MyfGtx5q25iNJ0FShMvqSg==,type:str]
+        - ENC[AES256_GCM,data:YlmD+4tIFtV1kDX30MEtF6q8WJIeuUApB/s=,iv:Gzt/j5B7THfHFenFhBfyawMIeccFq9MG0mtsc4aRMEQ=,tag:Yycxafd5LRYZQx3LPtSl3w==,type:str]
 sops:
     age:
         - recipient: age1w02zzfg0y4ast9mgnd9w0yuym0wqx6q967kmrmq355w4cnw0xytq2x369r
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhc3RuMFZiMzVtWG1Ub1BS
-            UW9LbGJXMjkxOHphQzZwVDZLTzVQSHZiMFJnCnpQczNoeENqamVaSzZtME14Wlpa
-            cUx4WjVHWEw3NUpxNXBFbXFvVGZnL1UKLS0tIFpLOXJrM09wVS9FN253cWRwQTJl
-            MXE2QmVhdkVUSzhLV3NORUVPNllMSmcKIKVqos/Oa+6SmZ69PTP/FoypI6Q9lKrl
-            wlOyP7XLYuzw/jV3TloRdnqTRgAkJZbnyhPMo3Lopq+fL3vErstZwQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1TzNFbG9BcXpUazQ0blJH
+            NXdSN2lsS3ZxcTA1R3RuZ0J1Z013aXdTMDE0CitIUHk4dzRqcjBlY0V3SjdwMk0z
+            SG1rNEFzcDV4a0tLZlRnZGIrRkI0bUUKLS0tIDFjeloxQ3dyMGFhdHlGQm9ITDd0
+            RlFqSDFvckRHWmZxQkV1aEp2Wm9mL00Ko9elNL7xu1cZHnWYNbSeT6WadTg/OdXC
+            gdxm9ZLXS3h0F8+B54tSfOxERE2PxXwr/UQV471ZbKP7uesGqUNRtQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-14T12:29:39Z"
-    mac: ENC[AES256_GCM,data:uaiMK6mzNzaRI9PnzC8y3hlAcqY/VuSO2Bf/kVhSGTTfPDlYCNgRS+G3GRK+4SdnLMVELEkM41HZ5qzU4Fn/YsXc4AE4eKFiUvaP9LC/HX/Pyw3ODzKteQpKZRsnhidCMwmofxxtJUzgDO/Qv8Z2mJy/yDS9rfKTT7tfiF/GOLM=,iv:8y4hdbCGagtvC1eewwV/pQ8lZQpBJNziLZg5Sx9h5HQ=,tag:GNb8WGJkL+be38/NqaGY5w==,type:str]
+    lastmodified: "2026-06-21T20:52:39Z"
+    mac: ENC[AES256_GCM,data:UgAiycu/xhK4d61nzgW6Q2vLh5qHOlSQWTBvVShjLp34N8hwJUNLcxIVMJ2jYb00J4pylWQSpVBr3xsJ2hFrxGWoc3klCdS6OmWYaZQi8Q5gCB9cKeWbveyTDMJDL+bqOykSj3Bpmp64N4erHw2omkd9kqXJ4mycjoa5LF9VSEg=,iv:rM/xPSRR058t5Da67J5VR3jP5TKtVGuLUtx6PPeLp2o=,tag:ldH0KO/cxSVCTIUEYoFCkA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2


### PR DESCRIPTION
Kubernetes 1.36 enforces strict --node-labels validation; node-role.kubernetes.io/* labels can no longer be set via kubelet flags. Apply the label post-join via kubectl.