### PR TITLE
fix(cnpg): fix backup alert threshold and stagger weekly schedules

### DIFF
--- a/kubernetes/apps/databases/cnpg-auth/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cnpg-auth-weekly
   namespace: databases
 spec:
-  schedule: "0 0 5 * * 0"
+  schedule: "0 15 5 * * 0"
   backupOwnerReference: self
   immediate: true
   cluster:

--- a/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/prometheusrule.yaml
@@ -11,13 +11,13 @@ spec:
       rules:
         - alert: CNPGLastBackupTooOld
           expr: |
-            (time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="databases"}) > 93600
+            (time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace="databases"}) > 691200
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: CNPG last backup too old ({{ $labels.pod }})
-            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 26 hours.\n  VALUE = {{ $value }}s"
+            description: "Last available backup for {{ $labels.namespace }}/{{ $labels.pod }} is older than 8 days.\n  VALUE = {{ $value }}s"
 
         - alert: CNPGWALArchivingFailing
           expr: |

--- a/kubernetes/apps/databases/cnpg-default/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-default/app/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cnpg-default-weekly
   namespace: databases
 spec:
-  schedule: "0 0 5 * * 0"
+  schedule: "0 30 5 * * 0"
   backupOwnerReference: self
   immediate: true
   cluster:

--- a/kubernetes/apps/databases/cnpg-immich/app/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cnpg-immich/app/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cnpg-immich-weekly
   namespace: databases
 spec:
-  schedule: "0 0 5 * * 0"
+  schedule: "0 45 5 * * 0"
   backupOwnerReference: self
   immediate: true
   cluster:


### PR DESCRIPTION
## Summary

- Raise `CNPGLastBackupTooOld` alert threshold from 26h to 8d to match the weekly backup cadence (alert was firing 6/7 days as noise)
- Stagger the four weekly `ScheduledBackup` crons by 15 minutes each to avoid concurrent load on Versity Gateway