### PR TITLE
fix(cnpg): reduce WAL retention to shrink Longhorn snapshot overhead

### DIFF
--- a/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-auth/app/cluster.yaml
@@ -20,9 +20,9 @@ spec:
         name: pocketid-credentials
   postgresql:
     parameters:
-      wal_keep_size: "128MB"
-      max_wal_size: "512MB"
-      max_slot_wal_keep_size: "512MB"
+      wal_keep_size: "32MB"
+      max_wal_size: "64MB"
+      max_slot_wal_keep_size: "64MB"
   affinity:
     enablePodAntiAffinity: true
     podAntiAffinityType: required

--- a/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg-media/app/cluster.yaml
@@ -18,9 +18,9 @@ spec:
       owner: seer
   postgresql:
     parameters:
-      wal_keep_size: "128MB"
-      max_wal_size: "512MB"
-      max_slot_wal_keep_size: "512MB"
+      wal_keep_size: "64MB"
+      max_wal_size: "128MB"
+      max_slot_wal_keep_size: "128MB"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
cnpg-auth: max_wal_size 512M→64M, wal_keep_size 128M→32M, max_slot_wal_keep_size 512M→64M
cnpg-media: max_wal_size 512M→128M, wal_keep_size 128M→64M, max_slot_wal_keep_size 512M→128M

Fewer WAL segments on disk means smaller daily Longhorn snapshot deltas. Projects cnpg-auth volumes from 138-192% → ~50% and cnpg-media from 113% → ~81% over 7 days as old snapshots age out.