### PR TITLE
feat(vpn-gateway): add VPN health probe and alerting

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -38,6 +38,12 @@ spec:
           - name: dead-mans-switch
             webhook_configs:
               - url: ${HEALTHCHECKS_IO_URL}
+        inhibit_rules:
+          - source_matchers:
+              - alertname="GluetunVPNDown"
+            target_matchers:
+              - alertname="KubernetesPodCrashLooping"
+              - namespace=~"media|vpn-gateway"
         route:
           group_by: ["alertname", "job"]
           group_wait: 1m

--- a/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn-gateway/gateway/app/helmrelease.yaml
@@ -42,6 +42,22 @@ spec:
             envFrom:
               - secretRef:
                   name: vpn-gateway-pod-gateway
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        STATUS=$(wget -q -T 10 -O- https://www.privateinternetaccess.com/api/client/status 2>/dev/null)
+                        echo "$STATUS" | grep -q '"connected":true' && exit 0 || exit 1
+                  initialDelaySeconds: 30
+                  periodSeconds: 60
+                  failureThreshold: 5
+                  timeoutSeconds: 15
             securityContext:
               capabilities:
                 add:

--- a/kubernetes/apps/vpn-gateway/gateway/app/kustomization.yaml
+++ b/kubernetes/apps/vpn-gateway/gateway/app/kustomization.yaml
@@ -5,4 +5,5 @@ namespace: vpn-gateway
 resources:
   - ./helmrelease.yaml
   - ./networkpolicy.yaml
+  - ./prometheusrule.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/vpn-gateway/gateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/vpn-gateway/gateway/app/prometheusrule.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vpn-gateway-rules
+  namespace: vpn-gateway
+spec:
+  groups:
+    - name: vpn-gateway.rules
+      rules:
+        - alert: GluetunVPNDown
+          expr: |
+            rate(kube_pod_container_status_restarts_total{namespace="vpn-gateway",container="gluetun"}[15m]) * 900 > 3
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: VPN tunnel is down (PIA/WireGuard)
+            description: "Gluetun has restarted more than 3 times in 15 minutes. WireGuard peer is unreachable or PIA connectivity check is failing. All media namespace pods will lose network access."


### PR DESCRIPTION
- Add gluetun liveness probe using PIA connectivity API to verify tunnel integrity
- Add GluetunVPNDown PrometheusRule with VPN-specific alert message
- Add Alertmanager inhibit rule suppressing KubernetesPodCrashLooping for media and vpn-gateway namespaces when VPN is down