### PR TITLE
fix(kube-prometheus-stack): drop duplicate alertmanager datasource

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -425,13 +425,6 @@ spec:
           jsonData:
             timeout: 60
             maxLines: 200
-        - name: AlertManager
-          uid: alertmanager
-          type: alertmanager
-          access: proxy
-          url: http://alertmanager-operated.monitoring.svc.cluster.local:9093
-          jsonData:
-            implementation: "prometheus"
       sidecar:
         dashboards:
           enabled: true


### PR DESCRIPTION
## Summary
- Grafana was crash-looping on startup with `Datasource provisioning error: data source with the same uid already exists`.
- The custom `AlertManager` entry in `additionalDataSources` duplicated `uid: alertmanager`, which the chart already provisions by default. Grafana 12's provisioning platform treats a duplicate UID as a fatal error (older versions only warned).
- Removed the redundant custom entry; the chart default covers the same Alertmanager.